### PR TITLE
Add customizable speed rules

### DIFF
--- a/content.js
+++ b/content.js
@@ -3,6 +3,7 @@ let playbackSpeed = 1.0; // Default to 1x speed
 let pressKey = "ArrowRight"; // Default key
 let autoPressNext = false; // Default to disabled
 let removeEyeTracker = false; // Default to disabled
+let customSpeedRules = [];
 
 // Function to store event data from the selected row
 function saveEventData(video) {
@@ -63,6 +64,9 @@ function saveEventData(video) {
 
     let eventData = { eventType, truckNumber, timestamp, pageUrl, isLastCell };
 
+    // store event type on the video for speed rules
+    video.dataset.eventType = eventType;
+
     chrome.storage.local.get("eventLogs", function (data) {
         let logs = data.eventLogs || [];
         logs.push(eventData);
@@ -111,8 +115,16 @@ function pressKeyEvent(key) {
 // Function to apply playback speed
 function applyPlaybackSpeed(video) {
     if (video) {
-        video.playbackRate = playbackSpeed;
-        console.log(`⚡ Playback speed set to ${playbackSpeed}x for`, video);
+        let speed = playbackSpeed;
+        const type = video.dataset.eventType || "";
+        for (const rule of customSpeedRules) {
+            if (rule.eventType === type) {
+                speed = parseFloat(rule.speed);
+                break;
+            }
+        }
+        video.playbackRate = speed;
+        console.log(`⚡ Playback speed set to ${speed}x for`, type, video);
     }
 }
 
@@ -237,15 +249,23 @@ chrome.runtime.onMessage.addListener((request) => {
         pressKey = request.pressKey;
         console.log("🔑 Key press updated to: " + pressKey);
     }
+
+    if (request.customSpeedRules) {
+        customSpeedRules = request.customSpeedRules;
+        console.log("⚡ Custom speed rules updated:", customSpeedRules);
+        let videos = document.querySelectorAll("video.gvVideo.controllerless, .videos.hide-tracking video");
+        videos.forEach(video => applyPlaybackSpeed(video));
+    }
 });
 
 // Load settings on startup and check for videos
-chrome.storage.sync.get(["enabled", "playbackSpeed", "pressKey", "autoPressNext", "removeEyeTracker"], function (data) {
+chrome.storage.sync.get(["enabled", "playbackSpeed", "pressKey", "autoPressNext", "removeEyeTracker", "customSpeedRules"], function (data) {
     isEnabled = data.enabled || false;
     playbackSpeed = parseFloat(data.playbackSpeed) || 1.0; // Default to 1x speed
     pressKey = data.pressKey || "ArrowDown"; // Default key is now Down Arrow
     autoPressNext = data.autoPressNext ?? false; // Default to disabled
     removeEyeTracker = data.removeEyeTracker ?? false; // Default to disabled
+    customSpeedRules = data.customSpeedRules || [];
 
     console.log("⚙️ Extension loaded with settings: Enabled=" + isEnabled + ", Speed=" + playbackSpeed + "x, Key=" + pressKey + ", Auto Press Next=" + autoPressNext + ", Remove Eye Tracker=" + removeEyeTracker);
 

--- a/log.html
+++ b/log.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta charset="UFC-8">
+<meta charset="UTF-8">
     <title>Event Log</title>
     <style>
         body {
@@ -25,6 +25,17 @@
         .button-group {
             display: flex;
             gap: 10px;
+        }
+
+        #openSettings {
+            background: none;
+            border: none;
+            color: #fff;
+            cursor: pointer;
+            font-size: 18px;
+            position: absolute;
+            top: 10px;
+            right: 10px;
         }
 
         #clearLogs,
@@ -114,10 +125,10 @@
             color: #ccc;
             font-size: 12px;
         }
-    </style>
+</style>
 </head>
-<meta charset="UFC-8">
 <body>
+    <button id="openSettings" title="Settings">\u2699</button>
     <!-- Bookmarks Section -->
     <div class="section-header">
         <h2>Bookmarked Events <span id="bookmarkCount">(0)</span></h2>

--- a/log.js
+++ b/log.js
@@ -7,6 +7,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const eventCount = document.getElementById("eventCount");
     const bookmarkCount = document.getElementById("bookmarkCount");
     const filterInput = document.getElementById("filterInput");
+    const openSettingsButton = document.getElementById("openSettings");
 
     let logs = [];
 
@@ -87,6 +88,12 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // Filtering
     filterInput.addEventListener("input", () => updateDisplays(logs));
+
+    if (openSettingsButton) {
+        openSettingsButton.addEventListener("click", () => {
+            window.open("settings.html");
+        });
+    }
 
     // Export to CSV
     exportCSVButton.addEventListener("click", function () {

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Settings</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #222;
+            color: #fff;
+            padding: 20px;
+        }
+        h2 {
+            margin-top: 0;
+        }
+        .rule {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 10px;
+        }
+        select {
+            background-color: #333;
+            color: #fff;
+            border: 1px solid #555;
+            padding: 5px;
+            border-radius: 5px;
+        }
+        button {
+            padding: 5px 10px;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+        #addRule {
+            background-color: #28a745;
+            color: #fff;
+        }
+        .remove {
+            background-color: #dc3545;
+            color: #fff;
+        }
+        #saveSettings {
+            background-color: #007bff;
+            color: #fff;
+            margin-top: 10px;
+        }
+    </style>
+</head>
+<body>
+    <h2>Settings</h2>
+    <h3>Custom Speed</h3>
+    <div id="rulesContainer"></div>
+    <button id="addRule">+</button>
+    <br>
+    <button id="saveSettings">Save</button>
+    <script src="settings.js"></script>
+</body>
+</html>

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,68 @@
+const eventTypes = ['Searching Face', 'Blocked', 'Micro Sleep', 'Microsleep', 'Distraction'];
+const speeds = ['1', '1.25', '1.5', '2'];
+
+document.addEventListener('DOMContentLoaded', () => {
+    const rulesContainer = document.getElementById('rulesContainer');
+    const addRuleBtn = document.getElementById('addRule');
+    const saveBtn = document.getElementById('saveSettings');
+
+    function createRuleRow(rule) {
+        const div = document.createElement('div');
+        div.className = 'rule';
+
+        const eventSelect = document.createElement('select');
+        eventTypes.forEach(type => {
+            const opt = document.createElement('option');
+            opt.value = type;
+            opt.textContent = type;
+            eventSelect.appendChild(opt);
+        });
+        eventSelect.value = rule?.eventType || eventTypes[0];
+
+        const speedSelect = document.createElement('select');
+        speeds.forEach(sp => {
+            const opt = document.createElement('option');
+            opt.value = sp;
+            opt.textContent = sp + 'x';
+            speedSelect.appendChild(opt);
+        });
+        speedSelect.value = rule?.speed || speeds[0];
+
+        const removeBtn = document.createElement('button');
+        removeBtn.textContent = '-';
+        removeBtn.className = 'remove';
+        removeBtn.addEventListener('click', () => div.remove());
+
+        div.appendChild(eventSelect);
+        div.appendChild(speedSelect);
+        div.appendChild(removeBtn);
+        rulesContainer.appendChild(div);
+    }
+
+    addRuleBtn.addEventListener('click', () => createRuleRow());
+
+    chrome.storage.sync.get({ customSpeedRules: [] }, data => {
+        const rules = data.customSpeedRules;
+        if (rules.length === 0) {
+            createRuleRow();
+        } else {
+            rules.forEach(r => createRuleRow(r));
+        }
+    });
+
+    saveBtn.addEventListener('click', () => {
+        const rules = [];
+        rulesContainer.querySelectorAll('.rule').forEach(div => {
+            const [eventSelect, speedSelect] = div.querySelectorAll('select');
+            rules.push({ eventType: eventSelect.value, speed: speedSelect.value });
+        });
+        chrome.storage.sync.set({ customSpeedRules: rules }, () => {
+            chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+                if (tabs[0]) {
+                    chrome.tabs.sendMessage(tabs[0].id, { customSpeedRules: rules });
+                }
+            });
+            alert('Settings saved');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- add gear button on the log page to open new settings page
- implement new settings page where custom playback speeds can be configured per event type
- support applying custom speed rules in `content.js`
- support Microsleep event type in settings
- fix charset meta in log page

## Testing
- `node --check content.js`
- `node --check log.js`
- `node --check popup.js`
- `node --check settings.js`
- `tidy -errors -q log.html`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68796af9041c8323a041403fee5941a4