### PR TITLE
Improve loop timer conditions

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,67 +1,83 @@
 let isEnabled = false;
 let playbackSpeed = 1.0; // Default to 1x speed
-let pressKey = "ArrowRight"; // Default key
+let pressKey = "ArrowDown"; // Default key is Down Arrow
 let autoPressNext = false; // Default to disabled
 let removeEyeTracker = false; // Default to disabled
+let customSpeedRules = [];
+let noVideoSkipDelay = 0;
+let noVideoTimerId = null;
+let smartSkipEnabled = false;
+let keyDelay = 2; // Delay after video ends before pressing Right Arrow
+let loopingEnabled = false;
+let loopReset = 10;
+let loopHold = 5;
+let loopFollow = true;
+let loopTimerId = null;
+let lastLoopSignature = "";
+let loopCheckIntervalId = null;
+let siteRules = {};
 
-// Function to store event data from the selected row
-function saveEventData(video) {
+function isAnyVideoPlaying() {
+    const vids = document.querySelectorAll("video.gvVideo.controllerless, .videos.hide-tracking video");
+    return Array.from(vids).some(v => !v.paused && !v.ended);
+}
+
+function extractEventData(video) {
     let allRows = document.querySelectorAll(".gvEventListItemPadding");
     let selectedRow = document.querySelector(".gvEventListItemPadding.selected.primarysel");
-    let isHideTracking = video.closest(".videos.hide-tracking") !== null; // Check if the video is inside hide-tracking
+    let isHideTracking = false;
+    if (video) {
+        isHideTracking = video.closest(".videos.hide-tracking") !== null;
+    } else if (document.querySelector(".videos.hide-tracking .item.selected")) {
+        isHideTracking = true;
+    }
 
     let eventType = "";
-    let truckNumber = ""; // Leave blank for hide-tracking
+    let truckNumber = "";
     let timestamp = "";
-    let pageUrl = window.location.href;
     let isLastCell = false;
 
     if (isHideTracking) {
-        // Get the selected container within hide-tracking
-        let selectedItem = document.querySelector(".item.selected");
-
+        let selectedItem = document.querySelector(".videos.hide-tracking .item.selected");
         if (selectedItem) {
             let eventTypeElement = selectedItem.querySelector("label.field-event_type");
             let timestampElement = selectedItem.querySelector("label.field-created_at");
-
-            if (eventTypeElement) {
-                eventType = eventTypeElement.textContent.trim();
-            }
-            if (timestampElement) {
-                timestamp = timestampElement.textContent.trim();
-            }
-
-            console.log("📌 Logging event from hide-tracking video (selected item):", { eventType, timestamp, pageUrl });
-        } else {
-            console.warn("⚠️ No selected item found for hide-tracking video.");
+            if (eventTypeElement) eventType = eventTypeElement.textContent.trim();
+            if (timestampElement) timestamp = timestampElement.textContent.trim();
         }
     } else if (selectedRow) {
-        // Normal gvVideo.controllerless logging
         isLastCell = selectedRow === allRows[allRows.length - 1];
-
         let eventTypeElement = selectedRow.querySelector(".gvEventListItemRight[style*='color']");
         let truckNumberElements = selectedRow.querySelectorAll(".gvEventListItemLeft");
         let timestampElement = selectedRow.querySelector(".gvEventListItemRight[style*='width: 90%']");
-
         let truckNumberElement = (truckNumberElements.length > 1) ? truckNumberElements[1] : null;
-
-        if (eventTypeElement) {
-            eventType = eventTypeElement.textContent.trim();
-        }
-        if (truckNumberElement) {
-            truckNumber = truckNumberElement.textContent.trim();
-        }
-        if (timestampElement) {
-            timestamp = timestampElement.textContent.trim();
-        }
-
-        console.log("📌 Logging event from normal video:", { eventType, truckNumber, timestamp, pageUrl, isLastCell });
+        if (eventTypeElement) eventType = eventTypeElement.textContent.trim();
+        if (truckNumberElement) truckNumber = truckNumberElement.textContent.trim();
+        if (timestampElement) timestamp = timestampElement.textContent.trim();
     } else {
+        return null;
+    }
+
+    return { eventType, truckNumber, timestamp, isLastCell };
+}
+
+// Function to store event data from the selected row
+function saveEventData(video) {
+    let info = extractEventData(video);
+    if (!info) {
         console.warn("⚠️ No selected row found for event logging.");
         return false;
     }
-
+    let { eventType, truckNumber, timestamp, isLastCell } = info;
+    let pageUrl = window.location.href;
     let eventData = { eventType, truckNumber, timestamp, pageUrl, isLastCell };
+
+    console.log("📌 Logging event:", eventData);
+
+    // store event type on the video for speed rules
+    if (video) {
+        video.dataset.eventType = eventType;
+    }
 
     chrome.storage.local.get("eventLogs", function (data) {
         let logs = data.eventLogs || [];
@@ -71,7 +87,7 @@ function saveEventData(video) {
         console.log("📌 Event logged successfully:", eventData);
     });
 
-    return isLastCell;
+    return { isLastCell, eventType };
 }
 
 
@@ -83,8 +99,8 @@ function pressKeyEvent(key) {
     let eventDown = new KeyboardEvent("keydown", {
         key: key,
         code: key,
-        keyCode: key === "ArrowRight" ? 39 : 40,
-        which: key === "ArrowRight" ? 39 : 40,
+        keyCode: key === "ArrowLeft" ? 37 : key === "ArrowUp" ? 38 : key === "ArrowRight" ? 39 : 40,
+        which: key === "ArrowLeft" ? 37 : key === "ArrowUp" ? 38 : key === "ArrowRight" ? 39 : 40,
         bubbles: true,
         cancelable: true
     });
@@ -92,8 +108,8 @@ function pressKeyEvent(key) {
     let eventUp = new KeyboardEvent("keyup", {
         key: key,
         code: key,
-        keyCode: key === "ArrowRight" ? 39 : 40,
-        which: key === "ArrowRight" ? 39 : 40,
+        keyCode: key === "ArrowLeft" ? 37 : key === "ArrowUp" ? 38 : key === "ArrowRight" ? 39 : 40,
+        which: key === "ArrowLeft" ? 37 : key === "ArrowUp" ? 38 : key === "ArrowRight" ? 39 : 40,
         bubbles: true,
         cancelable: true
     });
@@ -111,8 +127,127 @@ function pressKeyEvent(key) {
 // Function to apply playback speed
 function applyPlaybackSpeed(video) {
     if (video) {
-        video.playbackRate = playbackSpeed;
-        console.log(`⚡ Playback speed set to ${playbackSpeed}x for`, video);
+        let speed = playbackSpeed;
+        const type = video.dataset.eventType || "";
+        for (const rule of customSpeedRules) {
+            if (rule.eventType === type) {
+                speed = parseFloat(rule.speed);
+                break;
+            }
+        }
+        video.playbackRate = speed;
+        console.log(`⚡ Playback speed set to ${speed}x for`, type, video);
+    }
+}
+
+// Function to handle smart skip
+function cancelNoVideoTimer() {
+    if (noVideoTimerId) {
+        clearTimeout(noVideoTimerId);
+        noVideoTimerId = null;
+        console.log("⏹️ No-video timer canceled");
+    }
+}
+
+function startNoVideoTimer(info) {
+    if (!smartSkipEnabled || noVideoSkipDelay <= 0) return;
+    cancelNoVideoTimer();
+    const { eventType, isLastCell } = info || {};
+    console.log(`⏩ No video playback detected for ${eventType}; will skip in ${noVideoSkipDelay}s`);
+    noVideoTimerId = setTimeout(() => {
+        console.log("⏭️ Skipping due to no video playback");
+        let key = pressKey;
+        if (autoPressNext && isLastCell) {
+            key = "ArrowRight";
+        }
+        pressKeyEvent(key);
+    }, noVideoSkipDelay * 1000);
+}
+
+// Looping mode helpers
+function cancelLoopTimer() {
+    if (loopTimerId) {
+        clearTimeout(loopTimerId);
+        loopTimerId = null;
+        console.log("⏹️ Loop timer canceled");
+    }
+}
+
+function holdKey(key, seconds, callback) {
+    const element = document.activeElement || document;
+    const code = key === "ArrowLeft" ? 37 : key === "ArrowUp" ? 38 : key === "ArrowRight" ? 39 : 40;
+
+    const createDown = (repeat = false) => new KeyboardEvent("keydown", {
+        key,
+        code: key,
+        keyCode: code,
+        which: code,
+        bubbles: true,
+        cancelable: true,
+        repeat
+    });
+
+    const up = new KeyboardEvent("keyup", { key, code: key, keyCode: code, which: code, bubbles: true, cancelable: true });
+
+    element.dispatchEvent(createDown(false));
+    console.log(`⏮️ Holding ${key} for ${seconds}s`);
+
+    const intervalId = setInterval(() => {
+        element.dispatchEvent(createDown(true));
+    }, 100);
+
+    setTimeout(() => {
+        clearInterval(intervalId);
+        element.dispatchEvent(up);
+        console.log(`▶️ Released ${key}`);
+        if (callback) callback();
+    }, seconds * 1000);
+}
+
+function triggerLoop() {
+    holdKey("ArrowLeft", loopHold, () => {
+        if (loopFollow) {
+            pressKeyEvent("ArrowDown");
+            setTimeout(() => {
+                holdKey("ArrowUp", loopHold);
+            }, 500);
+        }
+    });
+}
+
+function scheduleLoop() {
+    if (!loopingEnabled || loopReset <= 0) return;
+    cancelLoopTimer();
+    console.log(`🔁 Loop scheduled in ${loopReset}s if event unchanged...`);
+    loopTimerId = setTimeout(triggerLoop, loopReset * 1000);
+}
+
+function checkLoop(info, playing) {
+    if (!loopingEnabled || !info || !info.isLastCell || playing) {
+        cancelLoopTimer();
+        lastLoopSignature = "";
+        return;
+    }
+    const sig = `${info.eventType}-${info.timestamp}`;
+    if (sig !== lastLoopSignature) {
+        lastLoopSignature = sig;
+        scheduleLoop();
+    }
+}
+
+function startLoopMonitor() {
+    if (loopCheckIntervalId) return;
+    loopCheckIntervalId = setInterval(() => {
+        const info = extractEventData(null);
+        const playing = isAnyVideoPlaying();
+        checkLoop(info, playing);
+    }, 1000);
+}
+
+function stopLoopMonitor() {
+    if (loopCheckIntervalId) {
+        clearInterval(loopCheckIntervalId);
+        loopCheckIntervalId = null;
     }
 }
 
@@ -136,18 +271,31 @@ function monitorVideos() {
 
     if (videos.length === 0) {
         console.warn("⚠️ No target videos found.");
+        const info = saveEventData(null);
+        if (info && info.eventType) {
+            startNoVideoTimer(info);
+            if (info.isLastCell) {
+                checkLoop(info, false);
+            }
+        }
         return;
     }
 
+    let firstInfo = null;
+    let playing = false;
     videos.forEach(video => {
         if (!video.dataset.listenerAdded) {
             console.log("🎥 Target video detected:", video);
 
             // Log event details based on video type
-            let isLastCell = saveEventData(video);
+            let info = saveEventData(video);
+            let isLastCell = info.isLastCell;
+            if (!firstInfo) firstInfo = info;
+            if (!video.paused) playing = true;
 
             // Apply the stored playback speed immediately
             applyPlaybackSpeed(video);
+            cancelNoVideoTimer();
 
             // If Remove Eye Tracker is enabled, check and remove it every time a video is detected
             if (removeEyeTracker) {
@@ -157,34 +305,45 @@ function monitorVideos() {
             video.addEventListener("play", () => {
                 console.log("✅ Video playing detected");
                 applyPlaybackSpeed(video);
+                cancelNoVideoTimer();
+                cancelLoopTimer();
             });
 
             video.addEventListener("ended", () => {
                 if (isEnabled) {
                     console.log("🎬 Video ended.");
 
-                    // Always press the Down Arrow first
-                    console.log("⬇️ Pressing Down Arrow immediately.");
-                    pressKeyEvent("ArrowDown");
+                    console.log(`⏳ Buffering for ${keyDelay}s before skipping...`);
+                    setTimeout(() => {
+                        console.log("⬇️ Pressing Down Arrow after delay.");
+                        pressKeyEvent("ArrowDown");
 
-                    // Only press Right Arrow if "Auto Press Next List" is enabled and it's the last cell
-                    chrome.storage.sync.get("autoPressNext", function (data) {
-                        if (data.autoPressNext && isLastCell) {
-                            console.log("⏳ Waiting 2 seconds before pressing Right Arrow...");
+                        if (autoPressNext && isLastCell) {
+                            console.log(`⏳ Waiting another ${keyDelay}s before pressing Right Arrow...`);
                             setTimeout(() => {
                                 console.log("➡️ Pressing Right Arrow after delay.");
                                 pressKeyEvent("ArrowRight");
-                            }, 2000);
-                        } else if (!data.autoPressNext) {
+                            }, keyDelay * 1000);
+                        } else if (!autoPressNext) {
                             console.log("🚫 Auto Press Next List is disabled. Right Arrow will not be pressed.");
                         }
-                    });
+                    }, keyDelay * 1000);
                 }
             }, { once: true });
 
             video.dataset.listenerAdded = "true";
         }
     });
+
+    if (!playing && firstInfo && firstInfo.eventType) {
+        startNoVideoTimer(firstInfo);
+        if (firstInfo.isLastCell) {
+            checkLoop(firstInfo, false);
+        }
+    } else if (playing) {
+        cancelNoVideoTimer();
+        cancelLoopTimer();
+    }
 }
 
 
@@ -208,6 +367,10 @@ chrome.runtime.onMessage.addListener((request) => {
         if (isEnabled) {
             monitorVideos();
             monitorForNewVideos();
+            if (loopingEnabled) startLoopMonitor();
+        } else {
+            stopLoopMonitor();
+            cancelLoopTimer();
         }
     }
 
@@ -237,21 +400,122 @@ chrome.runtime.onMessage.addListener((request) => {
         pressKey = request.pressKey;
         console.log("🔑 Key press updated to: " + pressKey);
     }
+
+    if (request.customSpeedRules) {
+        customSpeedRules = request.customSpeedRules;
+        console.log("⚡ Custom speed rules updated:", customSpeedRules);
+        let videos = document.querySelectorAll("video.gvVideo.controllerless, .videos.hide-tracking video");
+        videos.forEach(video => applyPlaybackSpeed(video));
+    }
+
+    if (request.siteRules) {
+        siteRules = request.siteRules;
+        console.log("🌐 Site rules updated:", siteRules);
+        const host = location.hostname;
+        if (siteRules[host]) {
+            const rule = siteRules[host];
+            if (rule.speed) {
+                playbackSpeed = parseFloat(rule.speed) || playbackSpeed;
+                document.querySelectorAll('video').forEach(v => applyPlaybackSpeed(v));
+            }
+            if (rule.disabled) {
+                if (isEnabled) {
+                    isEnabled = false;
+                    stopLoopMonitor();
+                    cancelLoopTimer();
+                }
+            } else {
+                chrome.storage.sync.get('enabled', data => {
+                    if (data.enabled) {
+                        isEnabled = true;
+                        monitorVideos();
+                        monitorForNewVideos();
+                        if (loopingEnabled) startLoopMonitor();
+                    }
+                });
+            }
+        }
+    }
+
+    if (request.skipDelay !== undefined) {
+        noVideoSkipDelay = parseFloat(request.skipDelay) || 0;
+        console.log("⏩ No-video skip delay updated:", noVideoSkipDelay);
+    }
+
+    if (request.keyDelay !== undefined) {
+        keyDelay = parseFloat(request.keyDelay) || 0;
+        console.log("⌛ Key press delay updated:", keyDelay);
+    }
+
+    if (request.loopingEnabled !== undefined) {
+        loopingEnabled = request.loopingEnabled;
+        console.log("🔁 Looping mode:", loopingEnabled);
+        if (!loopingEnabled) {
+            cancelLoopTimer();
+            stopLoopMonitor();
+        } else {
+            startLoopMonitor();
+        }
+    }
+
+    if (request.loopReset !== undefined) {
+        loopReset = parseFloat(request.loopReset) || 10;
+        console.log("🔄 Loop reset seconds:", loopReset);
+        if (loopingEnabled && lastLoopSignature) scheduleLoop();
+    }
+
+    if (request.loopHold !== undefined) {
+        loopHold = parseFloat(request.loopHold) || 5;
+        console.log("🕒 Loop hold seconds:", loopHold);
+    }
+
+    if (request.loopFollow !== undefined) {
+        loopFollow = request.loopFollow;
+        console.log("📼 Loop follow-up:", loopFollow);
+    }
+    if (request.smartSkipEnabled !== undefined) {
+        smartSkipEnabled = request.smartSkipEnabled;
+        console.log("⏩ Smart Skip enabled:", smartSkipEnabled);
+        if (!smartSkipEnabled) {
+            cancelNoVideoTimer();
+        }
+    }
 });
 
 // Load settings on startup and check for videos
-chrome.storage.sync.get(["enabled", "playbackSpeed", "pressKey", "autoPressNext", "removeEyeTracker"], function (data) {
+chrome.storage.sync.get(["enabled", "playbackSpeed", "pressKey", "autoPressNext", "removeEyeTracker", "customSpeedRules", "skipDelay", "smartSkipEnabled", "keyDelay", "loopingEnabled", "loopReset", "loopHold", "loopFollow", "siteRules"], function (data) {
     isEnabled = data.enabled || false;
     playbackSpeed = parseFloat(data.playbackSpeed) || 1.0; // Default to 1x speed
     pressKey = data.pressKey || "ArrowDown"; // Default key is now Down Arrow
     autoPressNext = data.autoPressNext ?? false; // Default to disabled
     removeEyeTracker = data.removeEyeTracker ?? false; // Default to disabled
+    customSpeedRules = data.customSpeedRules || [];
+    noVideoSkipDelay = parseFloat(data.skipDelay) || 0;
+    smartSkipEnabled = data.smartSkipEnabled ?? false;
+    keyDelay = parseFloat(data.keyDelay) || 2;
+    loopingEnabled = data.loopingEnabled ?? false;
+    loopReset = parseFloat(data.loopReset) || 10;
+    loopHold = parseFloat(data.loopHold) || 5;
+    loopFollow = data.loopFollow ?? true;
+    siteRules = data.siteRules || {};
 
-    console.log("⚙️ Extension loaded with settings: Enabled=" + isEnabled + ", Speed=" + playbackSpeed + "x, Key=" + pressKey + ", Auto Press Next=" + autoPressNext + ", Remove Eye Tracker=" + removeEyeTracker);
+    const host = location.hostname;
+    if (siteRules[host]) {
+        const rule = siteRules[host];
+        if (rule.disabled) {
+            isEnabled = false;
+        }
+        if (rule.speed) {
+            playbackSpeed = parseFloat(rule.speed) || playbackSpeed;
+        }
+    }
+
+    console.log("⚙️ Extension loaded with settings: Enabled=" + isEnabled + ", Speed=" + playbackSpeed + "x, Key=" + pressKey + ", Auto Press Next=" + autoPressNext + ", Remove Eye Tracker=" + removeEyeTracker + ", Key Delay=" + keyDelay + "s, Looping=" + loopingEnabled + ", Host=" + host);
 
     if (isEnabled) {
         monitorVideos();
         monitorForNewVideos();
+        if (loopingEnabled) startLoopMonitor();
     }
 
     if (removeEyeTracker) {

--- a/log.html
+++ b/log.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta charset="UFC-8">
+<meta charset="UTF-8">
     <title>Event Log</title>
     <style>
         body {
@@ -25,6 +25,23 @@
         .button-group {
             display: flex;
             gap: 10px;
+        }
+
+        #openSettings {
+            background-color: #007bff;
+            color: #fff;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            font-size: 14px;
+            padding: 8px 12px;
+            position: absolute;
+            top: 10px;
+            right: 10px;
+        }
+
+        #openSettings:hover {
+            background-color: #3399ff;
         }
 
         #clearLogs,
@@ -114,10 +131,10 @@
             color: #ccc;
             font-size: 12px;
         }
-    </style>
+</style>
 </head>
-<meta charset="UFC-8">
 <body>
+    <button id="openSettings" title="Settings">Settings</button>
     <!-- Bookmarks Section -->
     <div class="section-header">
         <h2>Bookmarked Events <span id="bookmarkCount">(0)</span></h2>

--- a/log.js
+++ b/log.js
@@ -7,6 +7,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const eventCount = document.getElementById("eventCount");
     const bookmarkCount = document.getElementById("bookmarkCount");
     const filterInput = document.getElementById("filterInput");
+    const openSettingsButton = document.getElementById("openSettings");
 
     let logs = [];
 
@@ -87,6 +88,12 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // Filtering
     filterInput.addEventListener("input", () => updateDisplays(logs));
+
+    if (openSettingsButton) {
+        openSettingsButton.addEventListener("click", () => {
+            window.open("settings.html");
+        });
+    }
 
     // Export to CSV
     exportCSVButton.addEventListener("click", function () {

--- a/popup.html
+++ b/popup.html
@@ -124,6 +124,11 @@
         <input type="checkbox" id="removeEyeTracker">
         Remove Eye Tracker
     </label>
+    <div style="margin-top: 8px;"></div>
+    <label>
+        <input type="checkbox" id="disableSite">
+        Disable for this site
+    </label>
 
     <p id="status">Status: <span id="statusText">Checking...</span></p>
 

--- a/popup.js
+++ b/popup.js
@@ -7,6 +7,22 @@ document.addEventListener("DOMContentLoaded", function () {
     let autoPressNextToggle = document.getElementById("autoPressNext");
     let removeEyeTrackerToggle = document.getElementById("removeEyeTracker");
     let viewLogsButton = document.getElementById("viewLogs");
+    let disableSiteToggle = document.getElementById("disableSite");
+
+    let currentHost = "";
+    chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+        if (tabs[0]) {
+            try {
+                currentHost = new URL(tabs[0].url).hostname;
+            } catch {}
+            chrome.storage.sync.get(["disabledSites", "siteRules"], data => {
+                const rules = data.siteRules || {};
+                const hostRule = rules[currentHost];
+                disableSiteToggle.checked = hostRule ? hostRule.disabled : false;
+                updateStatus(!(hostRule && hostRule.disabled) && (data.enabled ?? false));
+            });
+        }
+    });
     
     // Load stored settings
     chrome.storage.sync.get(["enabled", "playbackSpeed", "pressKey", "autoPressNext", "removeEyeTracker"], function (data) {
@@ -95,6 +111,23 @@ document.addEventListener("DOMContentLoaded", function () {
                 if (tabs.length > 0) {
                     chrome.tabs.sendMessage(tabs[0].id, { pressKey: selectedKey });
                 }
+            });
+        });
+    });
+
+    disableSiteToggle.addEventListener("change", function () {
+        const disabled = disableSiteToggle.checked;
+        chrome.storage.sync.get({ siteRules: {} }, data => {
+            const rules = data.siteRules;
+            if (!rules[currentHost]) rules[currentHost] = {};
+            rules[currentHost].disabled = disabled;
+            chrome.storage.sync.set({ siteRules: rules }, () => {
+                updateStatus(toggle.checked && !disabled);
+                chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+                    if (tabs[0]) {
+                        chrome.tabs.sendMessage(tabs[0].id, { siteRules: rules });
+                    }
+                });
             });
         });
     });

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Settings</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #222;
+            color: #fff;
+            padding: 20px;
+        }
+        h2 {
+            margin-top: 0;
+        }
+        .rule {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 10px;
+        }
+        select {
+            background-color: #333;
+            color: #fff;
+            border: 1px solid #555;
+            padding: 5px;
+            border-radius: 5px;
+        }
+        button {
+            padding: 5px 10px;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+        #addRule {
+            background-color: #28a745;
+            color: #fff;
+        }
+        .remove {
+            background-color: #dc3545;
+            color: #fff;
+        }
+        input[type="number"] {
+            background-color: #333;
+            color: #fff;
+            border: 1px solid #555;
+            padding: 5px;
+            border-radius: 5px;
+            width: 60px;
+        }
+        input[type="text"] {
+            background-color: #333;
+            color: #fff;
+            border: 1px solid #555;
+            padding: 5px;
+            border-radius: 5px;
+        }
+        #siteRulesContainer .rule {
+            align-items: center;
+        }
+        #addSiteRule {
+            background-color: #28a745;
+            color: #fff;
+        }
+        .disabled {
+            opacity: 0.5;
+            pointer-events: none;
+        }
+        #saveSettings {
+            background-color: #007bff;
+            color: #fff;
+            margin-top: 10px;
+        }
+    </style>
+</head>
+<body>
+    <h2>Settings</h2>
+    <h3>Custom Speed</h3>
+    <div id="rulesContainer"></div>
+    <button id="addRule">+</button>
+    <br>
+    <h3>Smart Skip</h3>
+    <label>
+        <input id="smartSkipToggle" type="checkbox"> Enable Smart Skip
+    </label>
+    <br>
+    <h3>Looping Mode</h3>
+    <label>
+        <input id="loopToggle" type="checkbox"> Looping Mode
+    </label>
+    <br>
+    <label id="loopResetContainer">
+        Seconds till "reset" <input id="loopReset" type="number" min="0" value="10">
+    </label>
+    <br>
+    <label id="loopHoldContainer">
+        Seconds held <input id="loopHold" type="number" min="0" value="5">
+    </label>
+    <br>
+    <label id="loopFollowContainer">
+        <input id="loopFollow" type="checkbox"> Follow up
+    </label>
+    <br>
+    <label id="skipContainer">
+        If No Video Playback is detected then skip after
+        <input id="skipDelay" type="number" min="0" max="30" value="0"> seconds
+    </label>
+    <br>
+    <h3>Site Overrides</h3>
+    <div id="siteRulesContainer"></div>
+    <button id="addSiteRule">+</button>
+    <br>
+    <h3>Buffer Between Videos</h3>
+    <label>
+        Buffer <input id="keyDelay" type="number" min="0" value="2"> seconds between videos
+    </label>
+    <br>
+    <button id="saveSettings">Save</button>
+    <script src="settings.js"></script>
+</body>
+</html>

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,197 @@
+const eventTypes = [
+    'Searching Face',
+    'Blocked',
+    'Micro Sleep',
+    'Microsleep',
+    'Distraction',
+    'Pending Review'
+];
+const speeds = ['1', '1.25', '1.5', '2'];
+
+document.addEventListener('DOMContentLoaded', () => {
+    const rulesContainer = document.getElementById('rulesContainer');
+    const addRuleBtn = document.getElementById('addRule');
+    const skipDelayInput = document.getElementById('skipDelay');
+    const smartSkipToggle = document.getElementById('smartSkipToggle');
+    const skipContainer = document.getElementById('skipContainer');
+    const keyDelayInput = document.getElementById('keyDelay');
+    const loopToggle = document.getElementById('loopToggle');
+    const loopResetInput = document.getElementById('loopReset');
+    const loopHoldInput = document.getElementById('loopHold');
+    const loopFollowToggle = document.getElementById('loopFollow');
+    const loopResetContainer = document.getElementById('loopResetContainer');
+    const loopHoldContainer = document.getElementById('loopHoldContainer');
+    const loopFollowContainer = document.getElementById('loopFollowContainer');
+    const saveBtn = document.getElementById('saveSettings');
+    const siteRulesContainer = document.getElementById('siteRulesContainer');
+    const addSiteRuleBtn = document.getElementById('addSiteRule');
+
+    function createSiteRuleRow(rule) {
+        const div = document.createElement('div');
+        div.className = 'rule';
+
+        const urlInput = document.createElement('input');
+        urlInput.type = 'text';
+        urlInput.placeholder = 'example.com';
+        urlInput.value = rule?.url || '';
+
+        const speedSelect = document.createElement('select');
+        speeds.forEach(sp => {
+            const opt = document.createElement('option');
+            opt.value = sp;
+            opt.textContent = sp + 'x';
+            speedSelect.appendChild(opt);
+        });
+        speedSelect.value = rule?.speed || speeds[0];
+
+        const disableCheck = document.createElement('input');
+        disableCheck.type = 'checkbox';
+        disableCheck.checked = rule?.disabled || false;
+
+        const removeBtn = document.createElement('button');
+        removeBtn.textContent = '-';
+        removeBtn.className = 'remove';
+        removeBtn.addEventListener('click', () => div.remove());
+
+        div.appendChild(urlInput);
+        div.appendChild(speedSelect);
+        div.appendChild(disableCheck);
+        div.appendChild(removeBtn);
+        siteRulesContainer.appendChild(div);
+    }
+
+    function updateSkipEnabled() {
+        if (smartSkipToggle.checked) {
+            skipContainer.classList.remove('disabled');
+            skipDelayInput.disabled = false;
+        } else {
+            skipContainer.classList.add('disabled');
+            skipDelayInput.disabled = true;
+        }
+    }
+
+    function updateLoopEnabled() {
+        const on = loopToggle.checked;
+        [loopResetContainer, loopHoldContainer, loopFollowContainer].forEach(el => {
+            if (on) {
+                el.classList.remove('disabled');
+                el.querySelectorAll('input').forEach(i => i.disabled = false);
+            } else {
+                el.classList.add('disabled');
+                el.querySelectorAll('input').forEach(i => i.disabled = true);
+            }
+        });
+    }
+
+    function createRuleRow(rule) {
+        const div = document.createElement('div');
+        div.className = 'rule';
+
+        const eventSelect = document.createElement('select');
+        eventTypes.forEach(type => {
+            const opt = document.createElement('option');
+            opt.value = type;
+            opt.textContent = type;
+            eventSelect.appendChild(opt);
+        });
+        eventSelect.value = rule?.eventType || eventTypes[0];
+
+        const speedSelect = document.createElement('select');
+        speeds.forEach(sp => {
+            const opt = document.createElement('option');
+            opt.value = sp;
+            opt.textContent = sp + 'x';
+            speedSelect.appendChild(opt);
+        });
+        speedSelect.value = rule?.speed || speeds[0];
+
+        const removeBtn = document.createElement('button');
+        removeBtn.textContent = '-';
+        removeBtn.className = 'remove';
+        removeBtn.addEventListener('click', () => div.remove());
+
+        div.appendChild(eventSelect);
+        div.appendChild(speedSelect);
+        div.appendChild(removeBtn);
+        rulesContainer.appendChild(div);
+    }
+
+    addRuleBtn.addEventListener('click', () => createRuleRow());
+    addSiteRuleBtn.addEventListener('click', () => createSiteRuleRow());
+
+    smartSkipToggle.addEventListener('change', updateSkipEnabled);
+    loopToggle.addEventListener('change', updateLoopEnabled);
+
+    chrome.storage.sync.get({ customSpeedRules: [], skipDelay: 0, smartSkipEnabled: false, keyDelay: 2, loopingEnabled: false, loopReset: 10, loopHold: 5, loopFollow: true, siteRules: {} }, data => {
+        const rules = data.customSpeedRules;
+        if (rules.length === 0) {
+            createRuleRow();
+        } else {
+            rules.forEach(r => createRuleRow(r));
+        }
+
+        smartSkipToggle.checked = data.smartSkipEnabled;
+        skipDelayInput.value = data.skipDelay || 0;
+        keyDelayInput.value = data.keyDelay ?? 2;
+        loopToggle.checked = data.loopingEnabled;
+        loopResetInput.value = data.loopReset ?? 10;
+        loopHoldInput.value = data.loopHold ?? 5;
+        loopFollowToggle.checked = data.loopFollow ?? true;
+        if (Object.keys(data.siteRules).length === 0) {
+            createSiteRuleRow();
+        } else {
+            Object.entries(data.siteRules).forEach(([url, cfg]) => {
+                createSiteRuleRow({ url, speed: cfg.speed, disabled: cfg.disabled });
+            });
+        }
+        updateSkipEnabled();
+        updateLoopEnabled();
+    });
+
+    saveBtn.addEventListener('click', () => {
+        const rules = [];
+        rulesContainer.querySelectorAll('.rule').forEach(div => {
+            const [eventSelect, speedSelect] = div.querySelectorAll('select');
+            rules.push({ eventType: eventSelect.value, speed: speedSelect.value });
+        });
+
+        let delay = parseFloat(skipDelayInput.value) || 0;
+        if (delay > 30) delay = 30;
+        skipDelayInput.value = delay;
+
+        let keyDelay = parseFloat(keyDelayInput.value);
+        if (isNaN(keyDelay) || keyDelay < 0) keyDelay = 0;
+        keyDelayInput.value = keyDelay;
+
+        const enabled = smartSkipToggle.checked;
+        const loopingEnabled = loopToggle.checked;
+
+        const siteRules = {};
+        siteRulesContainer.querySelectorAll('.rule').forEach(div => {
+            const [urlInput, speedSelect, disableCheck] = div.querySelectorAll('input, select');
+            const url = urlInput.value.trim();
+            if (url) {
+                siteRules[url] = { speed: speedSelect.value, disabled: disableCheck.checked };
+            }
+        });
+
+        chrome.storage.sync.set({ customSpeedRules: rules, skipDelay: delay, smartSkipEnabled: enabled, keyDelay, loopingEnabled, loopReset: parseFloat(loopResetInput.value) || 10, loopHold: parseFloat(loopHoldInput.value) || 5, loopFollow: loopFollowToggle.checked, siteRules }, () => {
+            chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+                if (tabs[0]) {
+                    chrome.tabs.sendMessage(tabs[0].id, {
+                        customSpeedRules: rules,
+                        skipDelay: enabled ? delay : 0,
+                        smartSkipEnabled: enabled,
+                        keyDelay,
+                        loopingEnabled,
+                        loopReset: parseFloat(loopResetInput.value) || 10,
+                        loopHold: parseFloat(loopHoldInput.value) || 5,
+                        loopFollow: loopFollowToggle.checked,
+                        siteRules
+                    });
+                }
+            });
+            alert('Settings saved');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- only schedule loops on the last queue item when nothing is playing
- cancel looping if playback resumes or selection changes
- add per-site overrides so sites can be disabled or run at different speeds

## Testing
- `node --check content.js`
- `node --check log.js`
- `node --check popup.js`
- `node --check settings.js`
- `tidy -errors -q log.html` *(failed: command not found)*
- `tidy -errors -q settings.html` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68796af9041c8323a041403fee5941a4