### PR TITLE
Refine QA Assist UI and logging workflows

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,41 @@
+const SITE_INFO_KEY = "siteInfo";
+const SITE_INFO_INITIALIZED_KEY = "siteInfoInitialized";
+const ICON_SIZES = [16, 32, 48, 128];
+
+function getIconPathMap(enabled) {
+    const iconFile = enabled ? "on.png" : "off.png";
+    return ICON_SIZES.reduce((paths, size) => {
+        paths[size] = iconFile;
+        return paths;
+    }, {});
+}
+
+function updateBrowserActionIcon(enabled) {
+    if (!chrome.browserAction || typeof chrome.browserAction.setIcon !== "function") {
+        return;
+    }
+
+    chrome.browserAction.setIcon({ path: getIconPathMap(Boolean(enabled)) });
+}
+
+chrome.storage.sync.get("enabled", (data) => {
+    updateBrowserActionIcon(Boolean(data.enabled));
+});
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName === "sync" && Object.prototype.hasOwnProperty.call(changes, "enabled")) {
+        updateBrowserActionIcon(Boolean(changes.enabled.newValue));
+    }
+});
+
+chrome.runtime.onMessage.addListener((message) => {
+    if (!message || message.type !== "updateBrowserIcon") {
+        return;
+    }
+
+    updateBrowserActionIcon(Boolean(message.enabled));
+});
+
 chrome.tabs.onActivated.addListener(() => {
     chrome.storage.sync.get("enabled", function (data) {
         chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
@@ -7,3 +45,171 @@ chrome.tabs.onActivated.addListener(() => {
         });
     });
 });
+
+chrome.runtime.onInstalled.addListener(() => {
+    initializeSiteDirectory();
+});
+chrome.runtime.onStartup.addListener(() => {
+    initializeSiteDirectory();
+});
+
+function initializeSiteDirectory() {
+    chrome.storage.sync.get([SITE_INFO_KEY, SITE_INFO_INITIALIZED_KEY], (data) => {
+        if (data[SITE_INFO_INITIALIZED_KEY]) {
+            return;
+        }
+
+        fetch(chrome.runtime.getURL("sitelist.txt"))
+            .then((response) => response.text())
+            .then((text) => {
+                const parsedEntries = parseSiteList(text);
+                if (!parsedEntries.length) {
+                    chrome.storage.sync.set({ [SITE_INFO_INITIALIZED_KEY]: true });
+                    return;
+                }
+
+                const existing = Array.isArray(data[SITE_INFO_KEY]) ? data[SITE_INFO_KEY] : [];
+                const merged = mergeSiteInfo(existing, parsedEntries);
+
+                chrome.storage.sync.set({
+                    [SITE_INFO_KEY]: merged,
+                    [SITE_INFO_INITIALIZED_KEY]: true,
+                });
+            })
+            .catch((error) => {
+                console.error("Failed to load site information", error);
+            });
+    });
+}
+
+function parseSiteList(text) {
+    if (!text) {
+        return [];
+    }
+
+    const lines = text.split(/\r?\n/);
+    const entries = [];
+
+    lines.forEach((line) => {
+        const trimmed = line.trim();
+        if (!trimmed) {
+            return;
+        }
+
+        const cleanedLine = trimmed.replace(/[\u200B-\u200D\uFEFF]/g, "");
+        const urlMatch = cleanedLine.match(/(https?:\/\/[^\s]+)/i);
+        const ipMatch = cleanedLine.match(/(\b\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?(?:\/[^\s]*)?)/);
+
+        let address = urlMatch ? urlMatch[1] : ipMatch ? ipMatch[1] : null;
+        if (!address) {
+            return;
+        }
+
+        address = address.replace(/^\(|\)$/g, "").trim();
+        let name = cleanedLine.replace(address, "").trim();
+        name = name.replace(/^[-–—]+/, "").trim();
+        name = name.replace(/\s{2,}/g, " ");
+
+        if (!name) {
+            name = address;
+        }
+
+        const entry = createSiteEntry(name.trim(), address.trim());
+        if (entry) {
+            entries.push(entry);
+        }
+    });
+
+    return entries;
+}
+
+function createSiteEntry(name, address) {
+    const matchValue = deriveMatchValue(address);
+    if (!matchValue) {
+        return null;
+    }
+
+    return {
+        id: generateId(),
+        name: name.trim(),
+        address: address.trim(),
+        matchValue,
+    };
+}
+
+function deriveMatchValue(address) {
+    if (!address) {
+        return "";
+    }
+
+    let cleaned = address.trim();
+    cleaned = cleaned.replace(/[\(\)]/g, "");
+
+    if (cleaned.startsWith("http://") || cleaned.startsWith("https://")) {
+        try {
+            const url = new URL(cleaned);
+            return url.hostname.toLowerCase();
+        } catch (error) {
+            cleaned = cleaned.replace(/^https?:\/\//, "");
+        }
+    }
+
+    cleaned = cleaned.replace(/^https?:\/\//, "");
+    cleaned = cleaned.replace(/\/$/, "");
+    cleaned = cleaned.replace(/:.*/, "");
+
+    return cleaned.toLowerCase();
+}
+
+function mergeSiteInfo(existingEntries, newEntries) {
+    const combined = new Map();
+
+    const allEntries = [...(existingEntries || []), ...(newEntries || [])];
+
+    allEntries.forEach((entry) => {
+        if (!entry) {
+            return;
+        }
+
+        const normalized = normalizeEntry(entry);
+        if (!normalized.matchValue) {
+            return;
+        }
+
+        if (!combined.has(normalized.matchValue)) {
+            combined.set(normalized.matchValue, normalized);
+        }
+    });
+
+    return Array.from(combined.values());
+}
+
+function normalizeEntry(entry) {
+    const normalized = { ...entry };
+
+    if (!normalized.id) {
+        normalized.id = generateId();
+    }
+
+    if (normalized.address) {
+        normalized.address = normalized.address.trim();
+    }
+
+    if (!normalized.matchValue) {
+        normalized.matchValue = deriveMatchValue(normalized.address || normalized.name || "");
+    }
+
+    if (normalized.name) {
+        normalized.name = normalized.name.trim();
+    }
+
+    return normalized;
+}
+
+function generateId() {
+    if (typeof crypto !== "undefined" && crypto.randomUUID) {
+        return crypto.randomUUID();
+    }
+
+    return `site-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+}

--- a/content.js
+++ b/content.js
@@ -1,28 +1,148 @@
 let isEnabled = false;
-let playbackSpeed = 1.0; // Default to 1x speed
-let pressKey = "ArrowRight"; // Default key
-let autoPressNext = false; // Default to disabled
-let removeEyeTracker = false; // Default to disabled
+let playbackSpeed = 1.0;
+let pressKey = "ArrowRight";
+let autoPressNext = false;
+let removeEyeTracker = false;
+let activeOverride = null;
+const processedEventKeys = new Set();
+let mutationObserver = null;
 
-// Function to store event data from the selected row
-function saveEventData(video) {
-    let allRows = document.querySelectorAll(".gvEventListItemPadding");
-    let selectedRow = document.querySelector(".gvEventListItemPadding.selected.primarysel");
-    let isHideTracking = video.closest(".videos.hide-tracking") !== null; // Check if the video is inside hide-tracking
+function getPageUrl() {
+    return window.location.href.split("#")[0];
+}
+
+function cleanValidationText(value) {
+    if (!value) {
+        return "";
+    }
+
+    return String(value)
+        .replace(/validation\s*type\s*:*/gi, "")
+        .replace(/validation\s*:*/gi, "")
+        .trim();
+}
+
+function extractValidationTypeFromElement(element) {
+    if (!element) {
+        return "";
+    }
+
+    const selectors = [
+        ".field-validation_type",
+        ".field-validationtype",
+        ".field-validation",
+        "[data-field='validation_type']",
+        "[data-field='validationtype']",
+        "[data-field='validation']",
+    ];
+
+    for (const selector of selectors) {
+        const node = element.querySelector(selector);
+        const text = cleanValidationText(node?.textContent);
+        if (text) {
+            return text;
+        }
+    }
+
+    const attributeKeys = ["data-validation-type", "data-validation_type", "data-validation"];
+    for (const attr of attributeKeys) {
+        if (element.hasAttribute(attr)) {
+            const text = cleanValidationText(element.getAttribute(attr));
+            if (text) {
+                return text;
+            }
+        }
+    }
+
+    const labelledNodes = Array.from(element.querySelectorAll("label, span, div, strong"));
+    for (const node of labelledNodes) {
+        const text = node.textContent;
+        if (!text) {
+            continue;
+        }
+
+        if (/validation/i.test(text)) {
+            const cleaned = cleanValidationText(text);
+            if (cleaned && cleaned !== text.trim()) {
+                return cleaned;
+            }
+
+            const nextSibling = node.nextElementSibling;
+            const siblingText = cleanValidationText(nextSibling?.textContent);
+            if (siblingText) {
+                return siblingText;
+            }
+
+            const parent = node.parentElement;
+            if (parent) {
+                const fallback = cleanValidationText(parent.textContent);
+                if (fallback && fallback !== text.trim()) {
+                    return fallback;
+                }
+            }
+        }
+    }
+
+    return "";
+}
+
+function determineValidationType(context = {}) {
+    const containers = [];
+
+    if (context.selectedRow) {
+        containers.push(context.selectedRow);
+    }
+    if (context.selectedItem) {
+        containers.push(context.selectedItem);
+    }
+
+    const inspectorSelectors = [
+        ".gvEventInspector",
+        ".gvEventDetailViewer",
+        ".event-details",
+        ".details-pane",
+    ];
+
+    inspectorSelectors.forEach((selector) => {
+        const node = document.querySelector(selector);
+        if (node) {
+            containers.push(node);
+        }
+    });
+
+    containers.push(document.body);
+
+    for (const container of containers) {
+        const extracted = extractValidationTypeFromElement(container);
+        if (extracted) {
+            return extracted;
+        }
+    }
+
+    return "";
+}
+
+function collectEventDetails(video) {
+    const allRows = document.querySelectorAll(".gvEventListItemPadding");
+    const selectedRow = document.querySelector(".gvEventListItemPadding.selected.primarysel");
+    const isHideTracking = video.closest(".videos.hide-tracking") !== null;
+
+    let selectedItem = null;
 
     let eventType = "";
-    let truckNumber = ""; // Leave blank for hide-tracking
+    let truckNumber = "";
     let timestamp = "";
-    let pageUrl = window.location.href;
+    let eventId = "";
+    const pageUrl = getPageUrl();
     let isLastCell = false;
 
     if (isHideTracking) {
-        // Get the selected container within hide-tracking
-        let selectedItem = document.querySelector(".item.selected");
+        selectedItem = document.querySelector(".item.selected");
 
         if (selectedItem) {
-            let eventTypeElement = selectedItem.querySelector("label.field-event_type");
-            let timestampElement = selectedItem.querySelector("label.field-created_at");
+            const eventTypeElement = selectedItem.querySelector("label.field-event_type");
+            const timestampElement = selectedItem.querySelector("label.field-created_at");
+            const eventIdElement = selectedItem.querySelector("label.field-eventid, label.field-event_id");
 
             if (eventTypeElement) {
                 eventType = eventTypeElement.textContent.trim();
@@ -30,178 +150,333 @@ function saveEventData(video) {
             if (timestampElement) {
                 timestamp = timestampElement.textContent.trim();
             }
-
-            console.log("📌 Logging event from hide-tracking video (selected item):", { eventType, timestamp, pageUrl });
-        } else {
-            console.warn("⚠️ No selected item found for hide-tracking video.");
+            if (eventIdElement) {
+                eventId = eventIdElement.textContent.trim();
+            }
         }
     } else if (selectedRow) {
-        // Normal gvVideo.controllerless logging
         isLastCell = selectedRow === allRows[allRows.length - 1];
 
-        let eventTypeElement = selectedRow.querySelector(".gvEventListItemRight[style*='color']");
-        let truckNumberElements = selectedRow.querySelectorAll(".gvEventListItemLeft");
-        let timestampElement = selectedRow.querySelector(".gvEventListItemRight[style*='width: 90%']");
+        const eventTypeElement = selectedRow.querySelector(".gvEventListItemRight[style*='color']");
+        const truckNumberElements = selectedRow.querySelectorAll(".gvEventListItemLeft");
+        const timestampElement = selectedRow.querySelector(".gvEventListItemRight[style*='width: 90%']");
 
-        let truckNumberElement = (truckNumberElements.length > 1) ? truckNumberElements[1] : null;
-
+        if (truckNumberElements.length > 0) {
+            eventId = (truckNumberElements[0]?.textContent || "").trim();
+        }
+        if (truckNumberElements.length > 1) {
+            truckNumber = (truckNumberElements[1]?.textContent || "").trim();
+        }
         if (eventTypeElement) {
             eventType = eventTypeElement.textContent.trim();
-        }
-        if (truckNumberElement) {
-            truckNumber = truckNumberElement.textContent.trim();
         }
         if (timestampElement) {
             timestamp = timestampElement.textContent.trim();
         }
-
-        console.log("📌 Logging event from normal video:", { eventType, truckNumber, timestamp, pageUrl, isLastCell });
     } else {
         console.warn("⚠️ No selected row found for event logging.");
-        return false;
+        return null;
     }
 
-    let eventData = { eventType, truckNumber, timestamp, pageUrl, isLastCell };
+    const validationType = determineValidationType({ selectedRow, selectedItem, isHideTracking });
 
-    chrome.storage.local.get("eventLogs", function (data) {
-        let logs = data.eventLogs || [];
-        logs.push(eventData);
+    const eventData = {
+        eventType,
+        truckNumber,
+        timestamp,
+        pageUrl,
+        isLastCell,
+        eventId,
+        validationType,
+    };
 
-        chrome.storage.local.set({ eventLogs: logs });
-        console.log("📌 Event logged successfully:", eventData);
-    });
-
-    return isLastCell;
+    return eventData;
 }
 
-
-
-// Function to simulate key press on the active element
-function pressKeyEvent(key) {
-    console.log(`⌨️ Pressing ${key} key...`);
-    
-    let eventDown = new KeyboardEvent("keydown", {
-        key: key,
-        code: key,
-        keyCode: key === "ArrowRight" ? 39 : 40,
-        which: key === "ArrowRight" ? 39 : 40,
-        bubbles: true,
-        cancelable: true
-    });
-
-    let eventUp = new KeyboardEvent("keyup", {
-        key: key,
-        code: key,
-        keyCode: key === "ArrowRight" ? 39 : 40,
-        which: key === "ArrowRight" ? 39 : 40,
-        bubbles: true,
-        cancelable: true
-    });
-
-    let targetElement = document.activeElement || document;
-    console.log("📩 Dispatching key events to:", targetElement);
-
-    targetElement.dispatchEvent(eventDown);
-    setTimeout(() => {
-        targetElement.dispatchEvent(eventUp);
-        console.log(`✔️ Key press event completed: ${key}`);
-    }, 100);
-}
-
-// Function to apply playback speed
-function applyPlaybackSpeed(video) {
-    if (video) {
-        video.playbackRate = playbackSpeed;
-        console.log(`⚡ Playback speed set to ${playbackSpeed}x for`, video);
+function createEventKey(eventData) {
+    if (!eventData) {
+        return "";
     }
+
+    const keyParts = [
+        eventData.eventId || "",
+        eventData.eventType || "",
+        eventData.truckNumber || "",
+        eventData.timestamp || "",
+        eventData.pageUrl || "",
+    ];
+
+    return keyParts.map((part) => String(part || "").trim().toLowerCase()).join("|");
 }
 
-// Function to remove Eye Tracker canvas whenever a video is detected
-function removeEyeTrackerElement() {
-    let eyeTrackerCanvas = document.querySelector("canvas.gvCvDetailViewer");
-    if (eyeTrackerCanvas) {
-        eyeTrackerCanvas.remove();
-        console.log("✅ Eye Tracker removed.");
-    } else {
-        console.log("⚠️ No Eye Tracker found.");
-    }
+function resolveSiteName(pageUrl) {
+    return new Promise((resolve) => {
+        chrome.storage.sync.get("siteInfo", (data) => {
+            const siteInfo = Array.isArray(data.siteInfo) ? data.siteInfo : [];
+
+            let siteName = "";
+            let siteMatchValue = "";
+
+            if (pageUrl) {
+                try {
+                    const url = new URL(pageUrl);
+                    const host = url.hostname.toLowerCase();
+
+                    const matchedEntry = siteInfo.find((entry) => {
+                        if (!entry) {
+                            return false;
+                        }
+                        const matchValue = (entry.matchValue || "").toLowerCase();
+                        if (!matchValue) {
+                            return false;
+                        }
+                        return host === matchValue || host.endsWith(`.${matchValue}`) || pageUrl.includes(matchValue);
+                    });
+
+                    if (matchedEntry) {
+                        siteName = matchedEntry.name || "";
+                        siteMatchValue = matchedEntry.matchValue || "";
+                    }
+                } catch (error) {
+                    console.warn("Unable to parse page URL for site lookup", error);
+                }
+            }
+
+            resolve({ siteName: siteName.trim(), siteMatchValue });
+        });
+    });
 }
 
-// Monitor video elements and store event data
-function monitorVideos() {
-    console.log("🔍 Running video monitor check...");
-
-    // Select both types of video elements
-    let videos = document.querySelectorAll("video.gvVideo.controllerless, .videos.hide-tracking video");
-
-    if (videos.length === 0) {
-        console.warn("⚠️ No target videos found.");
+function registerEventLog(eventData) {
+    if (!eventData) {
         return;
     }
 
-    videos.forEach(video => {
-        if (!video.dataset.listenerAdded) {
-            console.log("🎥 Target video detected:", video);
+    const eventKey = createEventKey(eventData);
+    if (!eventKey) {
+        return;
+    }
 
-            // Log event details based on video type
-            let isLastCell = saveEventData(video);
+    if (processedEventKeys.has(eventKey)) {
+        console.log("🔁 Duplicate event detected in-session. Skipping log entry.", eventData);
+        return;
+    }
 
-            // Apply the stored playback speed immediately
-            applyPlaybackSpeed(video);
+    processedEventKeys.add(eventKey);
 
-            // If Remove Eye Tracker is enabled, check and remove it every time a video is detected
-            if (removeEyeTracker) {
-                removeEyeTrackerElement();
+    resolveSiteName(eventData.pageUrl).then(({ siteName, siteMatchValue }) => {
+        const detectedValidation = cleanValidationText(eventData.validationType);
+        const enrichedEvent = {
+            ...eventData,
+            siteName,
+            siteMatchValue,
+            createdAt: new Date().toISOString(),
+            callHistory: [],
+            eventKey,
+            id: generateLogId(),
+            validationType: detectedValidation,
+            detectedValidation,
+        };
+
+        chrome.storage.local.get("eventLogs", (data) => {
+            const logs = Array.isArray(data.eventLogs) ? data.eventLogs : [];
+            const alreadyExists = logs.some((log) => createEventKey(log) === eventKey);
+
+            if (alreadyExists) {
+                console.log("🛑 Duplicate event detected in storage. Skipping log entry.", enrichedEvent);
+                return;
             }
 
-            video.addEventListener("play", () => {
-                console.log("✅ Video playing detected");
-                applyPlaybackSpeed(video);
-            });
-
-            video.addEventListener("ended", () => {
-                if (isEnabled) {
-                    console.log("🎬 Video ended.");
-
-                    // Always press the Down Arrow first
-                    console.log("⬇️ Pressing Down Arrow immediately.");
-                    pressKeyEvent("ArrowDown");
-
-                    // Only press Right Arrow if "Auto Press Next List" is enabled and it's the last cell
-                    chrome.storage.sync.get("autoPressNext", function (data) {
-                        if (data.autoPressNext && isLastCell) {
-                            console.log("⏳ Waiting 2 seconds before pressing Right Arrow...");
-                            setTimeout(() => {
-                                console.log("➡️ Pressing Right Arrow after delay.");
-                                pressKeyEvent("ArrowRight");
-                            }, 2000);
-                        } else if (!data.autoPressNext) {
-                            console.log("🚫 Auto Press Next List is disabled. Right Arrow will not be pressed.");
-                        }
-                    });
-                }
-            }, { once: true });
-
-            video.dataset.listenerAdded = "true";
-        }
+            logs.push(enrichedEvent);
+            chrome.storage.local.set({ eventLogs: logs });
+            console.log("📌 Event logged successfully:", enrichedEvent);
+        });
     });
 }
 
+function generateLogId() {
+    if (typeof crypto !== "undefined" && crypto.randomUUID) {
+        return crypto.randomUUID();
+    }
 
+    return `event-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+}
 
-// MutationObserver to detect dynamically loaded videos
+function pressKeyEvent(key) {
+    const eventDown = new KeyboardEvent("keydown", {
+        key,
+        code: key,
+        keyCode: key === "ArrowRight" ? 39 : key === "ArrowDown" ? 40 : undefined,
+        which: key === "ArrowRight" ? 39 : key === "ArrowDown" ? 40 : undefined,
+        bubbles: true,
+        cancelable: true,
+    });
+
+    const eventUp = new KeyboardEvent("keyup", {
+        key,
+        code: key,
+        keyCode: key === "ArrowRight" ? 39 : key === "ArrowDown" ? 40 : undefined,
+        which: key === "ArrowRight" ? 39 : key === "ArrowDown" ? 40 : undefined,
+        bubbles: true,
+        cancelable: true,
+    });
+
+    const targetElement = document.activeElement || document;
+    targetElement.dispatchEvent(eventDown);
+    setTimeout(() => targetElement.dispatchEvent(eventUp), 100);
+}
+
+function applyPlaybackSpeed(video) {
+    if (video) {
+        video.playbackRate = playbackSpeed;
+    }
+}
+
+function removeEyeTrackerElement() {
+    const eyeTrackerCanvas = document.querySelector("canvas.gvCvDetailViewer");
+    if (eyeTrackerCanvas) {
+        eyeTrackerCanvas.remove();
+        console.log("✅ Eye Tracker removed.");
+    }
+}
+
+function monitorVideos() {
+    const videos = document.querySelectorAll("video.gvVideo.controllerless, .videos.hide-tracking video");
+    if (!videos.length) {
+        return;
+    }
+
+    videos.forEach((video) => {
+        if (video.dataset.listenerAdded) {
+            return;
+        }
+
+        const eventData = collectEventDetails(video);
+        if (eventData) {
+            registerEventLog(eventData);
+        }
+
+        applyPlaybackSpeed(video);
+
+        if (removeEyeTracker) {
+            removeEyeTrackerElement();
+        }
+
+        video.addEventListener("play", () => applyPlaybackSpeed(video));
+
+        video.addEventListener(
+            "ended",
+            () => {
+                if (!isEnabled) {
+                    return;
+                }
+
+                pressKeyEvent("ArrowDown");
+
+                chrome.storage.sync.get("autoPressNext", (data) => {
+                    const shouldAutoPress = data.autoPressNext ?? autoPressNext;
+                    if (shouldAutoPress && eventData?.isLastCell) {
+                        setTimeout(() => pressKeyEvent("ArrowRight"), 2000);
+                    }
+                });
+            },
+            { once: true },
+        );
+
+        video.dataset.listenerAdded = "true";
+    });
+}
+
 function monitorForNewVideos() {
-    console.log("🔄 Starting MutationObserver for new videos...");
-    
-    const observer = new MutationObserver(() => {
-        console.log("🔍 Checking for newly added videos...");
+    if (mutationObserver) {
+        return;
+    }
+
+    mutationObserver = new MutationObserver(() => {
         monitorVideos();
     });
 
-    observer.observe(document.body, { childList: true, subtree: true });
+    mutationObserver.observe(document.body, { childList: true, subtree: true });
 }
 
-// Listen for messages from the popup (updates speed, key, toggles)
+function findOverrideForUrl(url, overrides) {
+    if (!url || !Array.isArray(overrides)) {
+        return null;
+    }
+
+    let host = "";
+    try {
+        host = new URL(url).hostname.toLowerCase();
+    } catch (error) {
+        host = url;
+    }
+
+    return (
+        overrides.find((override) => {
+            if (!override || !override.pattern) {
+                return false;
+            }
+
+            const pattern = String(override.pattern).toLowerCase();
+            return host === pattern || host.endsWith(`.${pattern}`) || url.toLowerCase().includes(pattern);
+        }) || null
+    );
+}
+
+function applyOverrideSettings(override) {
+    if (!override) {
+        activeOverride = null;
+        return;
+    }
+
+    activeOverride = override;
+
+    if (override.overridePlaybackSpeed && override.playbackSpeed) {
+        playbackSpeed = parseFloat(override.playbackSpeed) || playbackSpeed;
+    }
+
+    if (override.overridePressKey && override.pressKey) {
+        pressKey = override.pressKey;
+    }
+
+    if (typeof override.autoPressNext === "boolean") {
+        autoPressNext = override.autoPressNext;
+    }
+
+    if (typeof override.removeEyeTracker === "boolean") {
+        removeEyeTracker = override.removeEyeTracker;
+    }
+
+    if (typeof override.enableScanning === "boolean") {
+        isEnabled = override.enableScanning;
+    }
+}
+
+function loadSettingsAndInitialize() {
+    chrome.storage.sync.get(
+        ["enabled", "playbackSpeed", "pressKey", "autoPressNext", "removeEyeTracker", "siteOverrides"],
+        (data) => {
+            isEnabled = data.enabled || false;
+            playbackSpeed = parseFloat(data.playbackSpeed) || 1.0;
+            pressKey = data.pressKey || "ArrowDown";
+            autoPressNext = data.autoPressNext ?? false;
+            removeEyeTracker = data.removeEyeTracker ?? false;
+
+            const override = findOverrideForUrl(window.location.href, data.siteOverrides || []);
+            applyOverrideSettings(override);
+
+            if (isEnabled) {
+                monitorVideos();
+                monitorForNewVideos();
+            }
+
+            if (removeEyeTracker) {
+                removeEyeTrackerElement();
+            }
+        },
+    );
+}
+
 chrome.runtime.onMessage.addListener((request) => {
     if (request.enabled !== undefined) {
         isEnabled = request.enabled;
@@ -213,13 +488,10 @@ chrome.runtime.onMessage.addListener((request) => {
 
     if (request.autoPressNext !== undefined) {
         autoPressNext = request.autoPressNext;
-        console.log("🔄 Auto Press Next List updated:", autoPressNext);
     }
 
     if (request.removeEyeTracker !== undefined) {
         removeEyeTracker = request.removeEyeTracker;
-        console.log("👀 Remove Eye Tracker updated:", removeEyeTracker);
-        
         if (removeEyeTracker) {
             removeEyeTrackerElement();
         }
@@ -227,34 +499,18 @@ chrome.runtime.onMessage.addListener((request) => {
 
     if (request.playbackSpeed && playbackSpeed !== parseFloat(request.playbackSpeed)) {
         playbackSpeed = parseFloat(request.playbackSpeed);
-        console.log("⚡ Updating playback speed to:", playbackSpeed);
-        
-        let videos = document.querySelectorAll("video.gvVideo.controllerless");
-        videos.forEach(video => applyPlaybackSpeed(video));
+        const videos = document.querySelectorAll("video.gvVideo.controllerless, .videos.hide-tracking video");
+        videos.forEach((video) => applyPlaybackSpeed(video));
     }
 
     if (request.pressKey && pressKey !== request.pressKey) {
         pressKey = request.pressKey;
-        console.log("🔑 Key press updated to: " + pressKey);
+    }
+
+    if (request.siteOverrides) {
+        const override = findOverrideForUrl(window.location.href, request.siteOverrides);
+        applyOverrideSettings(override);
     }
 });
 
-// Load settings on startup and check for videos
-chrome.storage.sync.get(["enabled", "playbackSpeed", "pressKey", "autoPressNext", "removeEyeTracker"], function (data) {
-    isEnabled = data.enabled || false;
-    playbackSpeed = parseFloat(data.playbackSpeed) || 1.0; // Default to 1x speed
-    pressKey = data.pressKey || "ArrowDown"; // Default key is now Down Arrow
-    autoPressNext = data.autoPressNext ?? false; // Default to disabled
-    removeEyeTracker = data.removeEyeTracker ?? false; // Default to disabled
-
-    console.log("⚙️ Extension loaded with settings: Enabled=" + isEnabled + ", Speed=" + playbackSpeed + "x, Key=" + pressKey + ", Auto Press Next=" + autoPressNext + ", Remove Eye Tracker=" + removeEyeTracker);
-
-    if (isEnabled) {
-        monitorVideos();
-        monitorForNewVideos();
-    }
-
-    if (removeEyeTracker) {
-        removeEyeTrackerElement();
-    }
-});
+loadSettingsAndInitialize();

--- a/log.html
+++ b/log.html
@@ -1,164 +1,602 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-<meta charset="UFC-8">
-    <title>Event Log</title>
+    <meta charset="UTF-8">
+    <title>QA Assist · Event Log</title>
     <style>
+        :root {
+            color-scheme: dark;
+            --bg: #0b0e16;
+            --card: #141a27;
+            --border: #1e2636;
+            --text: #eef1ff;
+            --muted: #8793b2;
+            --accent: #4c8dff;
+            --accent-soft: rgba(76, 141, 255, 0.18);
+            --danger: #ff5c8d;
+            --success: #38d98a;
+            --overlay: rgba(5, 9, 16, 0.78);
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
         body {
-            font-family: Arial, sans-serif;
-            background-color: #222;
-            color: #fff;
-            padding: 20px;
+            margin: 0;
+            background: linear-gradient(180deg, rgba(76, 141, 255, 0.12), transparent), var(--bg);
+            color: var(--text);
+            font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+            padding: 32px 36px 48px;
+        }
+
+        h1 {
+            margin: 0 0 6px;
+            font-size: 28px;
+            letter-spacing: 0.02em;
         }
 
         h2 {
             margin: 0;
+            font-size: 20px;
+        }
+
+        p {
+            color: var(--muted);
+            margin: 4px 0 16px;
+        }
+
+        .nav-bar {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+            margin-bottom: 28px;
+        }
+
+        .nav-link {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 10px 16px;
+            border-radius: 999px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(255, 255, 255, 0.05);
+            color: var(--muted);
+            font-size: 13px;
+            font-weight: 600;
+            text-decoration: none;
+            transition: transform 0.15s ease, box-shadow 0.15s ease, color 0.15s ease;
+        }
+
+        .nav-link:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+        }
+
+        .nav-link.active {
+            color: #fff;
+            border-color: rgba(76, 141, 255, 0.35);
+            background: linear-gradient(135deg, rgba(76, 141, 255, 0.32), rgba(17, 21, 34, 0.85));
+            box-shadow: 0 18px 36px rgba(76, 141, 255, 0.28);
+        }
+
+        .header {
+            margin-bottom: 28px;
+        }
+
+        .section {
+            background: var(--card);
+            border-radius: 18px;
+            padding: 24px;
+            margin-bottom: 32px;
+            border: 1px solid var(--border);
+            box-shadow: 0 32px 60px rgba(0, 0, 0, 0.35);
         }
 
         .section-header {
             display: flex;
-            justify-content: space-between;
             align-items: center;
-            padding: 10px 0;
+            justify-content: space-between;
+            margin-bottom: 18px;
         }
 
-        .button-group {
-            display: flex;
-            gap: 10px;
-        }
-
-        #clearLogs,
-        #exportCSV {
-            background-color: #cc0000;
-            color: white;
-            border: none;
-            border-radius: 5px;
-            cursor: pointer;
+        .section-header span {
+            color: var(--muted);
             font-size: 14px;
-            padding: 8px 12px;
         }
 
-        #exportCSV {
-            background-color: #007bff;
+        .controls {
+            display: flex;
+            gap: 16px;
+            align-items: center;
+            margin-bottom: 18px;
         }
 
-        #clearLogs:hover {
-            background-color: #ff4444;
+        .controls input[type="text"] {
+            flex: 1;
+            padding: 10px 14px;
+            border-radius: 12px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(12, 16, 26, 0.85);
+            color: var(--text);
+            font-size: 14px;
         }
 
-        #exportCSV:hover {
-            background-color: #3399ff;
+        .controls button {
+            padding: 10px 16px;
+            border-radius: 12px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(255, 255, 255, 0.05);
+            color: var(--text);
+            cursor: pointer;
+            font-weight: 600;
+            transition: all 0.2s ease;
         }
 
-        #filterInput {
-            width: 100%;
-            padding: 8px;
-            margin: 10px 0;
-            border: 1px solid #555;
-            border-radius: 5px;
-            background-color: #333;
-            color: white;
+        .controls button.export {
+            border-color: rgba(76, 141, 255, 0.45);
+            background: var(--accent-soft);
+            color: var(--accent);
+        }
+
+        .controls button:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
         }
 
         table {
             width: 100%;
             border-collapse: collapse;
-            margin-top: 10px;
+            font-size: 13px;
+        }
+
+        thead {
+            background: rgba(255, 255, 255, 0.03);
         }
 
         th,
         td {
-            padding: 10px;
-            border: 1px solid #555;
+            padding: 12px 14px;
             text-align: left;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.08);
         }
 
         th {
-            background-color: #444;
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--muted);
         }
 
-        tr:nth-child(even) {
-            background-color: #333;
-        }
-
-        tr:hover {
-            background-color: #555;
+        tbody tr:hover {
+            background: rgba(76, 141, 255, 0.08);
         }
 
         a {
-            color: #66ccff;
+            color: var(--accent);
             text-decoration: none;
         }
 
         a:hover {
-            color: #99e6ff;
             text-decoration: underline;
         }
 
-        .mark-btn {
-            background-color: #88888800;
-            border: none;
-            color: #f0da00;
-            font-size: 15px;
+        .tag {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
             padding: 4px 8px;
-            border-radius: 2px;
+            border-radius: 999px;
+            background: rgba(76, 141, 255, 0.12);
+            border: 1px solid rgba(76, 141, 255, 0.35);
+            color: var(--accent);
+            font-size: 11px;
+            font-weight: 600;
+        }
+
+        .bookmark-button,
+        .call-button {
+            border: none;
+            background: transparent;
             cursor: pointer;
-            margin-left: 8px;
+            font-size: 16px;
+            transition: transform 0.15s ease;
         }
 
-        .mark-btn:hover {
-            background-color: #0000001f;
+        .call-button {
+            color: var(--accent);
         }
 
-        .comment-text {
-            color: #ccc;
+        .call-button:hover,
+        .bookmark-button:hover {
+            transform: scale(1.08);
+        }
+
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            padding: 4px 10px;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.08);
+            color: var(--muted);
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+
+        .badge.success {
+            background: rgba(56, 217, 138, 0.12);
+            color: var(--success);
+            border: 1px solid rgba(56, 217, 138, 0.35);
+        }
+
+        .modal {
+            position: fixed;
+            inset: 0;
+            background: var(--overlay);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+            z-index: 999;
+        }
+
+        .modal.show {
+            display: flex;
+        }
+
+        .modal-card {
+            width: min(720px, 100%);
+            background: var(--card);
+            border-radius: 20px;
+            border: 1px solid rgba(76, 141, 255, 0.3);
+            box-shadow: 0 48px 80px rgba(0, 0, 0, 0.45);
+            padding: 28px;
+            position: relative;
+        }
+
+        .modal-card h3 {
+            margin: 0 0 6px;
+            font-size: 22px;
+        }
+
+        .modal-card .subtitle {
+            color: var(--muted);
+            margin-bottom: 20px;
+        }
+
+        .close-modal {
+            position: absolute;
+            top: 18px;
+            right: 18px;
+            border: none;
+            background: rgba(255, 255, 255, 0.06);
+            color: var(--muted);
+            border-radius: 999px;
+            width: 32px;
+            height: 32px;
+            cursor: pointer;
+            font-size: 18px;
+        }
+
+        .grid {
+            display: grid;
+            gap: 16px;
+        }
+
+        .grid.two {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+
+        .summary-card {
+            background: rgba(255, 255, 255, 0.03);
+            border-radius: 14px;
+            padding: 16px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            display: grid;
+            gap: 6px;
+            font-size: 14px;
+        }
+
+        .summary-card strong {
+            color: var(--muted);
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+
+        .choice-buttons {
+            display: inline-flex;
+            gap: 12px;
+        }
+
+        .choice-buttons button {
+            padding: 8px 14px;
+            border-radius: 10px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(255, 255, 255, 0.04);
+            color: var(--text);
+            cursor: pointer;
+            font-weight: 600;
+        }
+
+        .choice-buttons button.active {
+            border-color: rgba(76, 141, 255, 0.45);
+            background: rgba(76, 141, 255, 0.18);
+            color: var(--accent);
+        }
+
+        .form-group {
+            margin-top: 18px;
+        }
+
+        .form-group label {
+            display: block;
             font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--muted);
+            margin-bottom: 6px;
+        }
+
+        .form-group input,
+        .form-group textarea {
+            width: 100%;
+            padding: 10px 12px;
+            border-radius: 12px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(11, 15, 25, 0.85);
+            color: var(--text);
+            font-size: 14px;
+        }
+
+        .form-group textarea {
+            min-height: 96px;
+            resize: vertical;
+        }
+
+        .modal-footer {
+            margin-top: 22px;
+            display: flex;
+            justify-content: space-between;
+            gap: 12px;
+        }
+
+        .modal-footer button {
+            flex: 1;
+            padding: 12px 18px;
+            border-radius: 14px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(255, 255, 255, 0.04);
+            color: var(--text);
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        .modal-footer button.primary {
+            background: linear-gradient(135deg, var(--accent), #6aa2ff);
+            border-color: transparent;
+            color: #fff;
+            box-shadow: 0 12px 24px rgba(76, 141, 255, 0.35);
+        }
+
+        .error-text {
+            color: var(--danger);
+            font-size: 12px;
+            margin-top: 6px;
+        }
+
+        .result-box {
+            margin-top: 16px;
+            padding: 16px;
+            border-radius: 14px;
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .result-box textarea {
+            min-height: 80px;
+        }
+
+        .time-summary {
+            display: grid;
+            gap: 10px;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            margin-bottom: 12px;
+        }
+
+        .summary-label {
+            display: block;
+            font-size: 11px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--muted);
+        }
+
+        .summary-value {
+            font-size: 14px;
+            font-weight: 600;
+        }
+
+        .copy-buttons {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 10px;
+            margin-top: 12px;
+        }
+
+        .copy-buttons button {
+            border-radius: 12px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(255, 255, 255, 0.06);
+            color: var(--text);
+            font-weight: 600;
+            padding: 10px 12px;
+            cursor: pointer;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        .copy-buttons button.primary {
+            background: linear-gradient(135deg, rgba(76, 141, 255, 0.42), rgba(49, 91, 170, 0.95));
+            color: #fff;
+            border-color: rgba(76, 141, 255, 0.45);
+            box-shadow: 0 14px 28px rgba(76, 141, 255, 0.28);
+        }
+
+        .copy-buttons button:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+        }
+
+        .hidden {
+            display: none !important;
+        }
+
+        @media (max-width: 900px) {
+            body {
+                padding: 24px;
+            }
+
+            .modal-card {
+                padding: 22px;
+            }
         }
     </style>
 </head>
-<meta charset="UFC-8">
 <body>
-    <!-- Bookmarks Section -->
-    <div class="section-header">
-        <h2>Bookmarked Events <span id="bookmarkCount">(0)</span></h2>
-    </div>
-    <table id="bookmarkTable">
-        <thead>
-            <tr>
-                <th>Event Type</th>
-                <th>Truck Number</th>
-                <th>Timestamp</th>
-                <th>Page URL</th>
-                <th>Comment</th>
-            </tr>
-        </thead>
-        <tbody id="bookmarkBody"></tbody>
-    </table>
+    <nav class="nav-bar">
+        <a class="nav-link active" href="log.html">Event Log</a>
+        <a class="nav-link" href="settings.html">Settings</a>
+        <a class="nav-link" href="site-info.html">Site Info</a>
+        <a class="nav-link" href="site-overrides.html">Site Overrides</a>
+    </nav>
+    <header class="header">
+        <h1>QA Assist — Event Log</h1>
+        <p>Review captured activity, manage bookmarks, and initiate call validations.</p>
+    </header>
 
-    <!-- Controls -->
-    <div class="section-header">
-        <h2>Recorded Events <span id="eventCount">(Watched 0 Events)</span></h2>
-        <div class="button-group">
-            <button id="exportCSV">Export to CSV</button>
+    <section class="section" id="bookmarkSection">
+        <div class="section-header">
+            <h2>Bookmarked Events</h2>
+            <span id="bookmarkCount" class="badge">0 items</span>
+        </div>
+        <table>
+            <thead>
+                <tr>
+                    <th>Event</th>
+                    <th>Truck</th>
+                    <th>Timestamp</th>
+                    <th>Site</th>
+                    <th>Page</th>
+                    <th>Comment</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody id="bookmarkBody"></tbody>
+        </table>
+    </section>
+
+    <section class="section">
+        <div class="section-header">
+            <h2>Recorded Events</h2>
+            <span id="eventCount" class="badge">0 items</span>
+        </div>
+        <div class="controls">
+            <input type="text" id="filterInput" placeholder="Search by event, truck, timestamp, site, or URL...">
+            <button id="exportCSV" class="export">Export CSV</button>
             <button id="clearLogs">Clear Logs</button>
+        </div>
+        <table>
+            <thead>
+                <tr>
+                    <th>Event ID</th>
+                    <th>Event Type</th>
+                    <th>Truck</th>
+                    <th>Timestamp</th>
+                    <th>Site</th>
+                    <th>Page URL</th>
+                    <th>Calls</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody id="logTableBody"></tbody>
+        </table>
+    </section>
+
+    <div class="modal" id="callModal">
+        <div class="modal-card">
+            <button class="close-modal" id="closeCallModal" title="Close">×</button>
+            <h3>Call Validation</h3>
+            <p class="subtitle">Confirm details for the call log entry and capture the Excel-ready row.</p>
+
+            <div class="grid two" style="margin-bottom: 20px;">
+                <div class="summary-card" id="callSummaryLeft"></div>
+                <div class="summary-card" id="callSummaryRight"></div>
+            </div>
+
+            <div class="form-group" id="validationPrompt">
+                <label>Validation Type</label>
+                <p style="margin: 0 0 8px; color: var(--muted);">Is this the correct validation type?</p>
+                <div class="choice-buttons" style="margin-bottom: 10px;">
+                    <button type="button" id="validationYes">Yes</button>
+                    <button type="button" id="validationNo">No</button>
+                </div>
+                <div class="tag" id="validationDisplay"></div>
+                <div class="form-group hidden" id="validationEditGroup" style="margin-top: 12px;">
+                    <label for="validationInput">Edit validation type</label>
+                    <input type="text" id="validationInput" placeholder="Enter validation type">
+                    <div class="choice-buttons" style="margin-top: 10px;">
+                        <button type="button" id="saveValidation" class="active">Save</button>
+                        <button type="button" id="cancelValidationEdit">Cancel</button>
+                    </div>
+                </div>
+                <div class="error-text hidden" id="validationError">Please confirm or adjust the validation type.</div>
+            </div>
+
+            <div class="form-group">
+                <label for="modalMonitorName">Monitor Name</label>
+                <input type="text" id="modalMonitorName" placeholder="Enter monitor name">
+                <div class="error-text hidden" id="monitorError">Please provide a monitor name.</div>
+            </div>
+
+            <div class="form-group">
+                <label>Contact Made?</label>
+                <div class="choice-buttons">
+                    <button type="button" id="contactYes">Yes</button>
+                    <button type="button" id="contactNo">No</button>
+                </div>
+                <div class="error-text hidden" id="contactError">Select the outcome of the call.</div>
+            </div>
+
+            <div class="result-box hidden" id="callResultBox">
+                <div class="time-summary">
+                    <div>
+                        <span class="summary-label">Event Time</span>
+                        <span class="summary-value" id="eventTimeSummary">—</span>
+                    </div>
+                    <div>
+                        <span class="summary-label">Call Times</span>
+                        <span class="summary-value" id="callTimeSummary">—</span>
+                    </div>
+                </div>
+                <div class="form-group" style="margin-top: 0;">
+                    <label for="tabOutput">Excel Row</label>
+                    <textarea id="tabOutput" readonly></textarea>
+                </div>
+                <div class="copy-buttons">
+                    <button id="copyTabOutput" class="primary">Copy Full Row</button>
+                    <button id="copyEventTime">Only Copy Event Time</button>
+                    <button id="copyCallTimes">Only Copy Call Time</button>
+                </div>
+            </div>
+
+            <div class="modal-footer">
+                <button type="button" class="ghost" id="cancelCall">Cancel</button>
+                <button type="button" class="primary" id="saveCall">Save Call</button>
+            </div>
         </div>
     </div>
 
-    <input type="text" id="filterInput" placeholder="Search events...">
-
-    <table>
-        <thead>
-            <tr>
-                <th>Event Type</th>
-                <th>Truck Number</th>
-                <th>Timestamp</th>
-                <th>Page URL</th>
-            </tr>
-        </thead>
-        <tbody id="logTableBody"></tbody>
-    </table>
-
     <script src="log.js"></script>
 </body>
-
 </html>

--- a/log.js
+++ b/log.js
@@ -1,5 +1,6 @@
-// log.js
-document.addEventListener("DOMContentLoaded", function () {
+// Enhanced log.js for QA Assist
+
+document.addEventListener("DOMContentLoaded", () => {
     const logTableBody = document.getElementById("logTableBody");
     const bookmarkBody = document.getElementById("bookmarkBody");
     const clearLogsButton = document.getElementById("clearLogs");
@@ -8,98 +9,873 @@ document.addEventListener("DOMContentLoaded", function () {
     const bookmarkCount = document.getElementById("bookmarkCount");
     const filterInput = document.getElementById("filterInput");
 
+    const callModal = document.getElementById("callModal");
+    const closeCallModalButton = document.getElementById("closeCallModal");
+    const cancelCallButton = document.getElementById("cancelCall");
+    const saveCallButton = document.getElementById("saveCall");
+    const copyTabOutputButton = document.getElementById("copyTabOutput");
+    const contactYesButton = document.getElementById("contactYes");
+    const contactNoButton = document.getElementById("contactNo");
+    const contactError = document.getElementById("contactError");
+    const monitorInput = document.getElementById("modalMonitorName");
+    const monitorError = document.getElementById("monitorError");
+    const validationDisplay = document.getElementById("validationDisplay");
+    const validationYesButton = document.getElementById("validationYes");
+    const validationNoButton = document.getElementById("validationNo");
+    const validationEditGroup = document.getElementById("validationEditGroup");
+    const validationInput = document.getElementById("validationInput");
+    const saveValidationButton = document.getElementById("saveValidation");
+    const cancelValidationEditButton = document.getElementById("cancelValidationEdit");
+    const validationError = document.getElementById("validationError");
+
+    const callResultBox = document.getElementById("callResultBox");
+    const tabOutput = document.getElementById("tabOutput");
+    const callSummaryLeft = document.getElementById("callSummaryLeft");
+    const callSummaryRight = document.getElementById("callSummaryRight");
+    const copyEventTimeButton = document.getElementById("copyEventTime");
+    const copyCallTimesButton = document.getElementById("copyCallTimes");
+    const eventTimeSummary = document.getElementById("eventTimeSummary");
+    const callTimeSummary = document.getElementById("callTimeSummary");
+
     let logs = [];
+    let activeCallState = null;
+    let lastTabSegments = null;
 
-    // Load logs
-    chrome.storage.local.get("eventLogs", function (data) {
-        logs = data.eventLogs || [];
-        updateDisplays(logs);
-    });
+    if (copyTabOutputButton) {
+        copyTabOutputButton.dataset.defaultLabel = copyTabOutputButton.textContent;
+    }
+    if (copyEventTimeButton) {
+        copyEventTimeButton.dataset.defaultLabel = copyEventTimeButton.textContent;
+    }
+    if (copyCallTimesButton) {
+        copyCallTimesButton.dataset.defaultLabel = copyCallTimesButton.textContent;
+    }
 
-    function updateDisplays(allLogs) {
-        const keyword = filterInput.value.toLowerCase();
-        const bookmarks = allLogs.filter(log => log.bookmarked);
-        const normalLogs = allLogs.filter(log => !log.bookmarked);
+    updateTimeSummaries(null);
 
-        // Filter normal by keyword
-        const filtered = normalLogs.filter(log =>
-            (log.eventType || "").toLowerCase().includes(keyword) ||
-            (log.truckNumber || "").toLowerCase().includes(keyword) ||
-            (log.timestamp || "").toLowerCase().includes(keyword) ||
-            (log.pageUrl || "").toLowerCase().includes(keyword)
-        );
+    function generateId() {
+        if (typeof crypto !== "undefined" && crypto.randomUUID) {
+            return crypto.randomUUID();
+        }
+        return `event-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+    }
 
-        // Update counts
-        eventCount.textContent = `(Watched ${normalLogs.length} Events)`;
-        bookmarkCount.textContent = `(${bookmarks.length} Bookmarked)`;
+    function createEventKey(log) {
+        if (!log) {
+            return "";
+        }
 
-        // Render bookmarks
-        bookmarkBody.innerHTML = "";
-        bookmarks.slice().reverse().forEach(log => {
-            const row = document.createElement("tr");
-            row.innerHTML = `
-                <td>${log.eventType || '—'}</td>
-                <td>${log.truckNumber || '—'}</td>
-                <td>${log.timestamp || '—'}</td>
-                <td>
-                  <a href="${log.pageUrl}" target="_blank">${log.pageUrl}</a>
-                  <button class="mark-btn">\u2605</button>
-                </td>
-                <td><span class="comment-text">${log.comment || ''}</span></td>
-            `;
-            row.querySelector('.mark-btn').addEventListener('click', () => {
-                log.bookmarked = false;
-                chrome.storage.local.set({ eventLogs: logs }, () => updateDisplays(logs));
-            });
-            bookmarkBody.appendChild(row);
+        const keyParts = [
+            log.eventId || "",
+            log.eventType || "",
+            log.truckNumber || "",
+            log.timestamp || "",
+            log.pageUrl || "",
+        ];
+
+        return keyParts.map((part) => String(part || "").trim().toLowerCase()).join("|");
+    }
+
+    function ensureLogShape(log) {
+        if (!log) {
+            return null;
+        }
+
+        const shaped = { ...log };
+
+        shaped.callHistory = Array.isArray(shaped.callHistory) ? shaped.callHistory : [];
+        shaped.eventKey = shaped.eventKey || createEventKey(shaped);
+        shaped.id = shaped.id || generateId();
+        shaped.detectedValidation = (shaped.detectedValidation || shaped.validationType || "").trim();
+        if (shaped.validationType) {
+            shaped.validationType = normalizeValidationType(shaped.validationType);
+        }
+
+        return shaped;
+    }
+
+    function deduplicateLogs(allLogs) {
+        const seen = new Set();
+        const deduped = [];
+
+        (allLogs || []).forEach((log) => {
+            const shaped = ensureLogShape(log);
+            if (!shaped) {
+                return;
+            }
+
+            const key = shaped.eventKey || createEventKey(shaped);
+            if (key && seen.has(key)) {
+                return;
+            }
+
+            if (key) {
+                seen.add(key);
+            }
+
+            deduped.push(shaped);
         });
 
-        // Render normal logs
-        logTableBody.innerHTML = "";
-        filtered.slice().reverse().forEach(log => {
-            const row = document.createElement("tr");
-            row.innerHTML = `
-                <td>${log.eventType || '—'}</td>
-                <td>${log.truckNumber || '—'}</td>
-                <td>${log.timestamp || '—'}</td>
-                <td>
-                  <a href="${log.pageUrl}" target="_blank">${log.pageUrl}</a>
-                  <button class="mark-btn">\u2606</button>
-                </td>
-            `;
-            row.querySelector('.mark-btn').addEventListener('click', () => {
-                const comment = prompt('Add a comment for this bookmark:');
-                log.bookmarked = true;
-                log.comment = comment || '';
-                chrome.storage.local.set({ eventLogs: logs }, () => updateDisplays(logs));
-            });
-            logTableBody.appendChild(row);
+        return deduped;
+    }
+
+    function saveLogs() {
+        chrome.storage.local.set({ eventLogs: logs });
+    }
+
+    function formatDate(date) {
+        return date.toLocaleDateString(undefined, {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
         });
     }
 
-    // Clear logs
-    clearLogsButton.addEventListener("click", function () {
+    function formatTime(date) {
+        return date.toLocaleTimeString(undefined, {
+            hour: "2-digit",
+            minute: "2-digit",
+            second: "2-digit",
+        });
+    }
+
+    function normalizeValidationType(value) {
+        const text = (value || "").trim();
+        if (!text) {
+            return "";
+        }
+
+        const lower = text.toLowerCase();
+
+        if (lower.includes("blocked")) {
+            return "Blocked";
+        }
+        if (lower.includes("critical")) {
+            return "Critical";
+        }
+        if (lower.includes("moderate")) {
+            return "Moderate";
+        }
+        if (/\blow\b/.test(lower)) {
+            return "3Low/hr";
+        }
+        if (lower.includes("cellphone") || lower.includes("cell phone") || lower.includes("cell-phone")) {
+            return "Cellphone";
+        }
+        if (lower.includes("lost") && lower.includes("connection")) {
+            return "Lost Connection";
+        }
+        if (/(?:^|\b)(?:false|non)/.test(lower)) {
+            return "False Positive";
+        }
+
+        return text;
+    }
+
+    function parseHourMinuteParts(value) {
+        if (value instanceof Date) {
+            return {
+                hour: String(value.getHours()),
+                minute: String(value.getMinutes()),
+            };
+        }
+
+        if (typeof value === "number") {
+            const dateFromNumber = new Date(value);
+            if (!Number.isNaN(dateFromNumber.getTime())) {
+                return {
+                    hour: String(dateFromNumber.getHours()),
+                    minute: String(dateFromNumber.getMinutes()),
+                };
+            }
+        }
+
+        if (typeof value === "string" && value.trim()) {
+            const parsed = Date.parse(value);
+            if (!Number.isNaN(parsed)) {
+                const parsedDate = new Date(parsed);
+                return {
+                    hour: String(parsedDate.getHours()),
+                    minute: String(parsedDate.getMinutes()),
+                };
+            }
+
+            const match = value.match(/(\d{1,2}):(\d{2})/);
+            if (match) {
+                return {
+                    hour: String(Number(match[1])),
+                    minute: String(Number(match[2])),
+                };
+            }
+        }
+
+        return { hour: "", minute: "" };
+    }
+
+    function describeTimeSegment(segment) {
+        if (!segment || (segment.hour === "" && segment.minute === "")) {
+            return "—";
+        }
+
+        const parts = [];
+        if (segment.hour !== "") {
+            parts.push(`${segment.hour} hr`);
+        }
+        if (segment.minute !== "") {
+            parts.push(`${segment.minute} min`);
+        }
+
+        return parts.length ? parts.join(" ") : "—";
+    }
+
+    function formatCallTimesSummary(callSegments = []) {
+        const labels = ["1st", "2nd", "3rd"];
+        return labels
+            .map((label, index) => {
+                const segment = callSegments[index] || { hour: "", minute: "" };
+                const description = describeTimeSegment(segment);
+                return `${label}: ${description}`;
+            })
+            .join(" · ");
+    }
+
+    function updateTimeSummaries(segments) {
+        if (!eventTimeSummary || !callTimeSummary) {
+            return;
+        }
+
+        if (!segments) {
+            eventTimeSummary.textContent = "—";
+            callTimeSummary.textContent = "—";
+            return;
+        }
+
+        eventTimeSummary.textContent = describeTimeSegment(segments.eventTime || { hour: "", minute: "" });
+        callTimeSummary.textContent = formatCallTimesSummary(segments.callTimes || []);
+    }
+
+    function copyTextWithFeedback(button, text, defaultLabel) {
+        if (!button) {
+            return;
+        }
+
+        const fallbackLabel = defaultLabel || button.dataset.defaultLabel || button.textContent || "Copy";
+        button.dataset.defaultLabel = fallbackLabel;
+
+        if (!navigator.clipboard) {
+            return;
+        }
+
+        navigator.clipboard
+            .writeText(text)
+            .then(() => {
+                button.textContent = "Copied!";
+                button.disabled = true;
+                setTimeout(() => {
+                    button.textContent = button.dataset.defaultLabel || fallbackLabel;
+                    button.disabled = false;
+                }, 1500);
+            })
+            .catch(() => {
+                button.textContent = "Copy failed";
+                setTimeout(() => {
+                    button.textContent = button.dataset.defaultLabel || fallbackLabel;
+                    button.disabled = false;
+                }, 1500);
+            });
+    }
+
+    function getLogById(id) {
+        return logs.find((log) => log.id === id);
+    }
+
+    function createBookmarkButton(log) {
+        const button = document.createElement("button");
+        button.className = "bookmark-button";
+        button.title = log.bookmarked ? "Remove bookmark" : "Bookmark event";
+        button.textContent = log.bookmarked ? "★" : "☆";
+
+        button.addEventListener("click", () => {
+            if (log.bookmarked) {
+                log.bookmarked = false;
+                log.comment = "";
+            } else {
+                const comment = prompt("Add a comment for this bookmark:", log.comment || "");
+                log.bookmarked = true;
+                log.comment = comment || "";
+            }
+            saveLogs();
+            updateDisplays(logs);
+        });
+
+        return button;
+    }
+
+    function createCallButton(log) {
+        const button = document.createElement("button");
+        button.className = "call-button";
+        button.textContent = "📞";
+        button.title = "Log call and generate Excel row";
+        button.addEventListener("click", () => openCallModal(log.id));
+        return button;
+    }
+
+    function renderBookmarkRow(log) {
+        const row = document.createElement("tr");
+
+        const eventCell = document.createElement("td");
+        eventCell.innerHTML = `<div>${log.eventType || "—"}</div><div class="badge" style="margin-top:6px;">${
+            log.eventId || "ID unavailable"
+        }</div>`;
+
+        const truckCell = document.createElement("td");
+        truckCell.textContent = log.truckNumber || "—";
+
+        const timestampCell = document.createElement("td");
+        timestampCell.textContent = log.timestamp || "—";
+
+        const siteCell = document.createElement("td");
+        siteCell.textContent = (log.siteName || "—").trim();
+
+        const pageCell = document.createElement("td");
+        pageCell.innerHTML = log.pageUrl
+            ? `<a href="${log.pageUrl}" target="_blank">${log.pageUrl}</a>`
+            : "—";
+
+        const commentCell = document.createElement("td");
+        commentCell.textContent = log.comment || "";
+
+        const actionsCell = document.createElement("td");
+        actionsCell.appendChild(createBookmarkButton(log));
+        actionsCell.appendChild(createCallButton(log));
+
+        row.appendChild(eventCell);
+        row.appendChild(truckCell);
+        row.appendChild(timestampCell);
+        row.appendChild(siteCell);
+        row.appendChild(pageCell);
+        row.appendChild(commentCell);
+        row.appendChild(actionsCell);
+
+        return row;
+    }
+
+    function renderLogRow(log) {
+        const row = document.createElement("tr");
+
+        const eventIdCell = document.createElement("td");
+        eventIdCell.textContent = log.eventId || "—";
+
+        const eventTypeCell = document.createElement("td");
+        eventTypeCell.textContent = log.eventType || "—";
+
+        const truckCell = document.createElement("td");
+        truckCell.textContent = log.truckNumber || "—";
+
+        const timestampCell = document.createElement("td");
+        timestampCell.textContent = log.timestamp || "—";
+
+        const siteCell = document.createElement("td");
+        siteCell.textContent = (log.siteName || "—").trim();
+
+        const pageCell = document.createElement("td");
+        pageCell.innerHTML = log.pageUrl
+            ? `<a href="${log.pageUrl}" target="_blank">${log.pageUrl}</a>`
+            : "—";
+
+        const callsCell = document.createElement("td");
+        const attempts = Array.isArray(log.callHistory) ? log.callHistory.length : 0;
+        callsCell.innerHTML = attempts
+            ? `<span class="badge success">${attempts} Call${attempts > 1 ? "s" : ""}</span>`
+            : "—";
+
+        const actionsCell = document.createElement("td");
+        actionsCell.style.display = "flex";
+        actionsCell.style.gap = "8px";
+        actionsCell.appendChild(createBookmarkButton(log));
+        actionsCell.appendChild(createCallButton(log));
+
+        row.appendChild(eventIdCell);
+        row.appendChild(eventTypeCell);
+        row.appendChild(truckCell);
+        row.appendChild(timestampCell);
+        row.appendChild(siteCell);
+        row.appendChild(pageCell);
+        row.appendChild(callsCell);
+        row.appendChild(actionsCell);
+
+        return row;
+    }
+
+    function updateDisplays(allLogs) {
+        const list = Array.isArray(allLogs) ? allLogs : logs;
+        const keyword = filterInput.value.trim().toLowerCase();
+
+        const bookmarks = list.filter((log) => log.bookmarked);
+        const normalLogs = list.filter((log) => !log.bookmarked);
+
+        const filteredNormals = normalLogs.filter((log) => {
+            const haystack = [
+                log.eventType,
+                log.truckNumber,
+                log.timestamp,
+                log.pageUrl,
+                log.siteName,
+                log.eventId,
+                log.validationType,
+                log.detectedValidation,
+            ]
+                .filter(Boolean)
+                .join(" ")
+                .toLowerCase();
+
+            return haystack.includes(keyword);
+        });
+
+        eventCount.textContent = `${filteredNormals.length} item${filteredNormals.length === 1 ? "" : "s"}`;
+        bookmarkCount.textContent = `${bookmarks.length} item${bookmarks.length === 1 ? "" : "s"}`;
+
+        bookmarkBody.innerHTML = "";
+        bookmarks
+            .slice()
+            .reverse()
+            .forEach((log) => {
+                bookmarkBody.appendChild(renderBookmarkRow(log));
+            });
+
+        logTableBody.innerHTML = "";
+        filteredNormals
+            .slice()
+            .reverse()
+            .forEach((log) => {
+                logTableBody.appendChild(renderLogRow(log));
+            });
+    }
+
+    function resetCallState() {
+        activeCallState = null;
+        callResultBox.classList.add("hidden");
+        tabOutput.value = "";
+        contactYesButton.classList.remove("active");
+        contactNoButton.classList.remove("active");
+        contactError.classList.add("hidden");
+        monitorError.classList.add("hidden");
+        validationError.classList.add("hidden");
+        validationEditGroup.classList.add("hidden");
+        validationInput.value = "";
+        callSummaryLeft.innerHTML = "";
+        callSummaryRight.innerHTML = "";
+        validationDisplay.textContent = "—";
+        validationDisplay.removeAttribute("title");
+        lastTabSegments = null;
+        updateTimeSummaries(null);
+        saveCallButton.disabled = false;
+
+        if (copyTabOutputButton) {
+            copyTabOutputButton.textContent = copyTabOutputButton.dataset.defaultLabel || "Copy Full Row";
+            copyTabOutputButton.disabled = false;
+        }
+        if (copyEventTimeButton) {
+            copyEventTimeButton.textContent = copyEventTimeButton.dataset.defaultLabel || "Only Copy Event Time";
+            copyEventTimeButton.disabled = false;
+        }
+        if (copyCallTimesButton) {
+            copyCallTimesButton.textContent = copyCallTimesButton.dataset.defaultLabel || "Only Copy Call Time";
+            copyCallTimesButton.disabled = false;
+        }
+    }
+
+    function closeCallModal() {
+        callModal.classList.remove("show");
+        resetCallState();
+    }
+
+    function openCallModal(logId) {
+        const log = getLogById(logId);
+        if (!log) {
+            return;
+        }
+
+        resetCallState();
+
+        const attempts = Array.isArray(log.callHistory) ? log.callHistory.length : 0;
+        const attemptNumber = attempts + 1;
+        const detectedValidation = (log.detectedValidation || "").trim();
+        const storedValidation = (log.validationType || "").trim();
+        const baseValidation = storedValidation || detectedValidation || (log.eventType || "").trim();
+        const normalizedDefault = normalizeValidationType(baseValidation);
+        const defaultValidation = normalizedDefault || baseValidation;
+
+        activeCallState = {
+            logId,
+            attemptNumber,
+            defaultValidation,
+            finalValidation: defaultValidation,
+            validationConfirmed: false,
+            contactSelection: null,
+            monitorName: "",
+            detectedValidation,
+        };
+
+        validationDisplay.textContent = defaultValidation || "—";
+        validationDisplay.className = "tag";
+        if (detectedValidation && detectedValidation !== defaultValidation) {
+            validationDisplay.title = `Detected: ${detectedValidation}`;
+        } else {
+            validationDisplay.removeAttribute("title");
+        }
+
+        callSummaryLeft.innerHTML = `
+            <strong>Event Type</strong>
+            <span>${log.eventType || "—"}</span>
+            <strong>Detected Validation</strong>
+            <span>${detectedValidation || "—"}</span>
+            <strong>Truck</strong>
+            <span>${log.truckNumber || "—"}</span>
+        `;
+
+        callSummaryRight.innerHTML = `
+            <strong>Timestamp</strong>
+            <span>${log.timestamp || "—"}</span>
+            <strong>Site</strong>
+            <span>${(log.siteName || "—").trim()}</span>
+            <strong>Attempts Logged</strong>
+            <span>${attempts}</span>
+            <strong>Page</strong>
+            <span>${log.pageUrl ? `<a href="${log.pageUrl}" target="_blank">${log.pageUrl}</a>` : "—"}</span>
+        `;
+
+        chrome.storage.sync.get("monitorName", (data) => {
+            const storedName = data.monitorName || "";
+            monitorInput.value = storedName;
+            activeCallState.monitorName = storedName;
+        });
+
+        callModal.classList.add("show");
+    }
+
+    function setContactSelection(value) {
+        if (!activeCallState) {
+            return;
+        }
+        activeCallState.contactSelection = value;
+        contactYesButton.classList.toggle("active", value === "yes");
+        contactNoButton.classList.toggle("active", value === "no");
+        contactError.classList.add("hidden");
+    }
+
+    function setValidationConfirmed(confirmed) {
+        if (!activeCallState) {
+            return;
+        }
+        activeCallState.validationConfirmed = confirmed;
+        validationError.classList.add("hidden");
+    }
+
+    function generateTabDelimitedRow(log, attemptRecord, monitorName) {
+        const now = attemptRecord ? new Date(attemptRecord.timestamp) : new Date();
+        const dateStr = formatDate(now);
+
+        const eventTimeSources = [log.timestamp, log.createdAt, log.createdOn];
+        let eventTimeParts = { hour: "", minute: "" };
+        for (const source of eventTimeSources) {
+            const parts = parseHourMinuteParts(source);
+            if (parts.hour !== "" || parts.minute !== "") {
+                eventTimeParts = parts;
+                break;
+            }
+        }
+
+        const attempts = Array.isArray(log.callHistory) ? log.callHistory : [];
+        const attemptEntries = [attempts[0], attempts[1], attempts[2]];
+        const callSegments = attemptEntries.map((entry) =>
+            entry ? parseHourMinuteParts(entry.timestamp) : { hour: "", minute: "" },
+        );
+
+        while (callSegments.length < 3) {
+            callSegments.push({ hour: "", minute: "" });
+        }
+
+        const contactMade = attemptRecord ? attemptRecord.contactMade : false;
+        const receptor = contactMade ? "Dispatch" : "";
+        const normalizedValidation = normalizeValidationType(
+            log.validationType || log.detectedValidation || log.eventType || "",
+        );
+        const trimmedMonitor = (monitorName || "").trim();
+
+        const rowValues = [
+            dateStr,
+            eventTimeParts.hour,
+            eventTimeParts.minute,
+            callSegments[0].hour,
+            callSegments[0].minute,
+            callSegments[1].hour,
+            callSegments[1].minute,
+            callSegments[2].hour,
+            callSegments[2].minute,
+            (log.siteName || "").trim(),
+            log.truckNumber || "",
+            normalizedValidation,
+            trimmedMonitor,
+            contactMade ? "Yes" : "No",
+            receptor,
+        ];
+
+        return {
+            rowString: rowValues.join("\t"),
+            rowValues,
+            segments: {
+                eventTime: eventTimeParts,
+                callTimes: callSegments,
+            },
+        };
+    }
+
+    function handleSaveCall() {
+        if (!activeCallState) {
+            return;
+        }
+
+        const log = getLogById(activeCallState.logId);
+        if (!log) {
+            closeCallModal();
+            return;
+        }
+
+        const monitorName = monitorInput.value.trim();
+        if (!monitorName) {
+            monitorError.classList.remove("hidden");
+            monitorInput.focus();
+            return;
+        }
+        monitorError.classList.add("hidden");
+        activeCallState.monitorName = monitorName;
+
+        if (!activeCallState.validationConfirmed) {
+            validationError.classList.remove("hidden");
+            return;
+        }
+        validationError.classList.add("hidden");
+
+        if (!activeCallState.contactSelection) {
+            contactError.classList.remove("hidden");
+            return;
+        }
+        contactError.classList.add("hidden");
+
+        const contactMade = activeCallState.contactSelection === "yes";
+        const timestamp = new Date().toISOString();
+
+        const finalValidationSource =
+            activeCallState.finalValidation ||
+            log.validationType ||
+            log.detectedValidation ||
+            log.eventType ||
+            "";
+        const normalizedFinal = normalizeValidationType(finalValidationSource);
+
+        log.validationType = normalizedFinal;
+        activeCallState.finalValidation = normalizedFinal;
+        log.monitorName = monitorName;
+        log.callHistory = Array.isArray(log.callHistory) ? log.callHistory : [];
+
+        const attemptRecord = {
+            attempt: activeCallState.attemptNumber,
+            timestamp,
+            contactMade,
+            receptor: contactMade ? "Dispatch" : "",
+        };
+
+        log.callHistory.push(attemptRecord);
+
+        const tabData = generateTabDelimitedRow(log, attemptRecord, monitorName);
+        attemptRecord.tabRow = tabData.rowString;
+        attemptRecord.tabSegments = tabData.segments;
+        lastTabSegments = tabData.segments;
+
+        chrome.storage.sync.set({ monitorName });
+        saveLogs();
+        updateDisplays(logs);
+
+        validationDisplay.textContent = normalizedFinal || "—";
+        if (activeCallState.detectedValidation && activeCallState.detectedValidation !== normalizedFinal) {
+            validationDisplay.title = `Detected: ${activeCallState.detectedValidation}`;
+        } else {
+            validationDisplay.removeAttribute("title");
+        }
+
+        tabOutput.value = tabData.rowString;
+        updateTimeSummaries(lastTabSegments);
+        callResultBox.classList.remove("hidden");
+        saveCallButton.disabled = true;
+    }
+
+    filterInput.addEventListener("input", () => updateDisplays(logs));
+
+    clearLogsButton.addEventListener("click", () => {
+        if (!logs.length) {
+            return;
+        }
+
         if (confirm("Are you sure you want to clear all logs?")) {
             logs = [];
-            chrome.storage.local.set({ eventLogs: [] }, () => updateDisplays(logs));
+            saveLogs();
+            updateDisplays(logs);
         }
     });
 
-    // Filtering
-    filterInput.addEventListener("input", () => updateDisplays(logs));
+    exportCSVButton.addEventListener("click", () => {
+        if (!logs.length) {
+            return;
+        }
 
-    // Export to CSV
-    exportCSVButton.addEventListener("click", function () {
-        let csvContent = "data:text/csv;charset=utf-8,Event Type,Truck Number,Timestamp,Page URL,Bookmarked,Comment\n";
-        logs.forEach(log => {
-            csvContent += `"${log.eventType}","${log.truckNumber}","${log.timestamp}","${log.pageUrl}","${log.bookmarked ? 'Yes' : 'No'}","${log.comment || ''}"\n`;
+        const header = [
+            "Event ID",
+            "Event Type",
+            "Truck Number",
+            "Timestamp",
+            "Site",
+            "Page URL",
+            "Calls",
+            "Validation Type",
+            "Monitor Name",
+            "Last Contact",
+            "Tab Row",
+        ];
+
+        const rows = logs.map((log) => {
+            const attempts = Array.isArray(log.callHistory) ? log.callHistory.length : 0;
+            const lastAttempt = attempts ? log.callHistory[attempts - 1] : null;
+
+            return [
+                log.eventId || "",
+                log.eventType || "",
+                log.truckNumber || "",
+                log.timestamp || "",
+                (log.siteName || "").trim(),
+                log.pageUrl || "",
+                attempts,
+                log.validationType || log.eventType || "",
+                log.monitorName || "",
+                lastAttempt ? (lastAttempt.contactMade ? "Contacted" : "No Contact") : "",
+                lastAttempt && lastAttempt.tabRow ? lastAttempt.tabRow.replace(/\t/g, " ") : "",
+            ]
+                .map((value) => `"${(value || "").replace(/"/g, '""')}"`)
+                .join(",");
         });
-        const encodedUri = encodeURI(csvContent);
+
+        const csvContent = [header.join(","), ...rows].join("\n");
+        const encodedUri = `data:text/csv;charset=utf-8,${encodeURIComponent(csvContent)}`;
         const link = document.createElement("a");
         link.setAttribute("href", encodedUri);
         link.setAttribute("download", "event_logs.csv");
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);
+    });
+
+    contactYesButton.addEventListener("click", () => setContactSelection("yes"));
+    contactNoButton.addEventListener("click", () => setContactSelection("no"));
+
+    validationYesButton.addEventListener("click", () => {
+        if (!activeCallState) {
+            return;
+        }
+        const normalized = normalizeValidationType(activeCallState.defaultValidation);
+        activeCallState.finalValidation = normalized;
+        validationDisplay.textContent = normalized || "—";
+        if (activeCallState.detectedValidation && activeCallState.detectedValidation !== normalized) {
+            validationDisplay.title = `Detected: ${activeCallState.detectedValidation}`;
+        } else {
+            validationDisplay.removeAttribute("title");
+        }
+        setValidationConfirmed(true);
+        validationEditGroup.classList.add("hidden");
+    });
+
+    validationNoButton.addEventListener("click", () => {
+        if (!activeCallState) {
+            return;
+        }
+        validationEditGroup.classList.remove("hidden");
+        validationInput.value = activeCallState.finalValidation || activeCallState.defaultValidation;
+        validationInput.focus();
+    });
+
+    saveValidationButton.addEventListener("click", () => {
+        if (!activeCallState) {
+            return;
+        }
+        const updated = validationInput.value.trim();
+        if (!updated) {
+            validationInput.focus();
+            return;
+        }
+        const normalized = normalizeValidationType(updated);
+        activeCallState.finalValidation = normalized;
+        validationDisplay.textContent = normalized || "—";
+        if (activeCallState.detectedValidation && activeCallState.detectedValidation !== normalized) {
+            validationDisplay.title = `Detected: ${activeCallState.detectedValidation}`;
+        } else {
+            validationDisplay.removeAttribute("title");
+        }
+        validationEditGroup.classList.add("hidden");
+        setValidationConfirmed(true);
+    });
+
+    cancelValidationEditButton.addEventListener("click", () => {
+        validationEditGroup.classList.add("hidden");
+        if (activeCallState) {
+            activeCallState.finalValidation = activeCallState.defaultValidation;
+        }
+    });
+
+    saveCallButton.addEventListener("click", handleSaveCall);
+
+    cancelCallButton.addEventListener("click", closeCallModal);
+    closeCallModalButton.addEventListener("click", closeCallModal);
+
+    copyTabOutputButton.addEventListener("click", () => {
+        const text = tabOutput.value;
+        if (typeof text !== "string") {
+            return;
+        }
+        copyTextWithFeedback(copyTabOutputButton, text, copyTabOutputButton.dataset.defaultLabel);
+    });
+
+    copyEventTimeButton.addEventListener("click", () => {
+        if (!lastTabSegments) {
+            return;
+        }
+        const eventTime = lastTabSegments.eventTime || { hour: "", minute: "" };
+        const values = [eventTime.hour || "", eventTime.minute || ""];
+        copyTextWithFeedback(copyEventTimeButton, values.join("\t"), copyEventTimeButton.dataset.defaultLabel);
+    });
+
+    copyCallTimesButton.addEventListener("click", () => {
+        if (!lastTabSegments) {
+            return;
+        }
+        const callSegments = Array.isArray(lastTabSegments.callTimes) ? lastTabSegments.callTimes : [];
+        const values = [];
+        for (let index = 0; index < 3; index += 1) {
+            const segment = callSegments[index] || { hour: "", minute: "" };
+            values.push(segment.hour || "");
+            values.push(segment.minute || "");
+        }
+        copyTextWithFeedback(copyCallTimesButton, values.join("\t"), copyCallTimesButton.dataset.defaultLabel);
+    });
+
+    window.addEventListener("keydown", (event) => {
+        if (event.key === "Escape" && callModal.classList.contains("show")) {
+            closeCallModal();
+        }
+    });
+
+    chrome.storage.local.get("eventLogs", (data) => {
+        const loadedLogs = Array.isArray(data.eventLogs) ? data.eventLogs : [];
+        logs = deduplicateLogs(loadedLogs);
+        saveLogs();
+        updateDisplays(logs);
     });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -4,11 +4,11 @@
 	"version": "1.456",
 	"description": "A tool to enhance QA workflows with automation and logging.",
 	"author": "Abel Orta",
-	"icons": {
-    "16": "icon.png",
-    "48": "icon.png",
-    "128": "icon.png"
-	},
+        "icons": {
+            "16": "icon.png",
+            "48": "icon.png",
+            "128": "icon.png"
+        },
 	
     "permissions": ["tabs", "storage", "activeTab", "scripting"],
     "background": {
@@ -23,7 +23,12 @@
     ],
     "browser_action": {
         "default_popup": "popup.html",
-        "default_icon": "icon.png"
+        "default_icon": {
+            "16": "off.png",
+            "32": "off.png",
+            "48": "off.png",
+            "128": "off.png"
+        }
     },
-    "options_page": "log.html"
+    "options_page": "settings.html"
 }

--- a/popup.html
+++ b/popup.html
@@ -3,131 +3,422 @@
 <head>
     <title>QA Assist</title>
     <style>
-        body { 
-            width: 230px; 
-            font-family: Arial, sans-serif; 
-            text-align: center; 
-            background-color: #222;
-            color: #fff;
-            padding: 10px;
-            border-radius: 5px;
-            position: relative;
+        :root {
+            color-scheme: dark;
+            --bg-color: #11141a;
+            --card-bg: #1b1f29;
+            --border-color: #242a38;
+            --text-primary: #f5f7ff;
+            --text-secondary: #9ba4c4;
+            --accent: #4c8dff;
+            --accent-glow: rgba(76, 141, 255, 0.45);
+            --danger: #ff5c8d;
+            --success: #3dd68c;
+            --warning: #f6c95f;
         }
 
-        h3, h4 {
-            color: #ddd;
-            margin-bottom: 5px;
+        * {
+            box-sizing: border-box;
         }
 
-        #toggle, #speed, #keySelect, #autoPressNext, #removeEyeTracker {
-            margin-top: 10px;
-            background-color: #333;
-            color: #fff;
-            border: 1px solid #555;
-            padding: 5px;
-            border-radius: 5px;
+        body {
+            width: 320px;
+            margin: 0;
+            padding: 16px;
+            font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+            background: radial-gradient(circle at top, rgba(76, 141, 255, 0.18), transparent 55%), var(--bg-color);
+            color: var(--text-primary);
         }
 
-        #toggle, #autoPressNext, #removeEyeTracker {
-            cursor: pointer;
+        h1 {
+            font-size: 18px;
+            margin: 0;
         }
 
-        select {
-            width: 100%;
+        h2 {
+            font-size: 15px;
+            margin: 0;
+            color: var(--text-primary);
         }
 
-        #status {
-            margin-top: 10px; 
-            font-weight: bold;
+        p {
+            margin: 4px 0 12px;
+            color: var(--text-secondary);
+            font-size: 12px;
         }
 
-        #statusText {
-            color: limegreen;
+        .container {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
         }
 
-        .dropdown-container {
+        .header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 12px;
+            border-radius: 14px;
+            background: linear-gradient(135deg, rgba(76, 141, 255, 0.35), rgba(17, 20, 26, 0.85));
+            border: 1px solid rgba(76, 141, 255, 0.35);
+            box-shadow: 0 12px 22px rgba(0, 0, 0, 0.35);
+        }
+
+        .header small {
+            display: block;
+            color: var(--text-secondary);
+            font-size: 11px;
+            margin-top: 4px;
+        }
+
+        .status-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 12px;
+            border-radius: 999px;
+            font-size: 12px;
+            font-weight: 600;
+            background: rgba(0, 0, 0, 0.25);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+        }
+
+        .status-dot {
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            background: var(--warning);
+            box-shadow: 0 0 8px rgba(246, 201, 95, 0.65);
+        }
+
+        .card {
+            background: var(--card-bg);
+            border-radius: 16px;
+            padding: 16px;
+            border: 1px solid var(--border-color);
+            box-shadow: 0 18px 30px rgba(0, 0, 0, 0.35);
+        }
+
+        .card-header {
             display: flex;
             justify-content: space-between;
             align-items: center;
+            margin-bottom: 12px;
         }
 
-        .dropdown-container div {
-            width: 48%;
-            text-align: left;
+        .badge {
+            font-size: 11px;
+            padding: 4px 10px;
+            border-radius: 999px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            border: 1px solid rgba(255, 255, 255, 0.14);
+            color: var(--text-secondary);
+            background: rgba(255, 255, 255, 0.05);
         }
 
-        #viewLogs {
-            margin-top: 15px;
-            padding: 8px;
-            width: 100%;
-            background-color: #007bff;
-            color: white;
-            border: none;
-            border-radius: 5px;
+        .badge.active {
+            color: var(--success);
+            border-color: rgba(61, 214, 140, 0.35);
+            background: rgba(61, 214, 140, 0.12);
+        }
+
+        .badge.alert {
+            color: var(--warning);
+            border-color: rgba(246, 201, 95, 0.35);
+            background: rgba(246, 201, 95, 0.12);
+        }
+
+        .badge.subtle {
+            color: var(--text-secondary);
+            border-color: rgba(255, 255, 255, 0.08);
+            background: rgba(255, 255, 255, 0.03);
+        }
+
+        .toggle {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            font-weight: 600;
+            font-size: 13px;
+        }
+
+        .toggle input {
+            appearance: none;
+            width: 46px;
+            height: 24px;
+            background: rgba(255, 255, 255, 0.18);
+            border-radius: 999px;
+            position: relative;
             cursor: pointer;
-            font-size: 14px;
+            transition: all 0.2s ease;
         }
 
-        #viewLogs:hover {
-            background-color: #3399ff;
-        }
-
-        /* Status Icon */
-        #statusIcon {
+        .toggle input::after {
+            content: "";
             position: absolute;
-            top: 5px;
-            right: 5px;
-            width: 48px;
-            height: 48px;
+            top: 3px;
+            left: 3px;
+            width: 18px;
+            height: 18px;
+            background: #0f131b;
+            border-radius: 50%;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.45);
+            transition: transform 0.2s ease;
+        }
+
+        .toggle input:checked {
+            background: linear-gradient(135deg, var(--accent), #64a8ff);
+            box-shadow: 0 0 12px var(--accent-glow);
+        }
+
+        .toggle input:checked::after {
+            transform: translateX(22px);
+            background: #fff;
+        }
+
+        .form-row {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            margin-bottom: 12px;
+        }
+
+        label {
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+
+        select,
+        input[type="text"] {
+            width: 100%;
+            padding: 8px 10px;
+            border-radius: 10px;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            background: rgba(15, 19, 27, 0.85);
+            color: var(--text-primary);
+            font-size: 13px;
+        }
+
+        input[type="text"]::placeholder {
+            color: rgba(255, 255, 255, 0.35);
+        }
+
+        .checkbox {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 12px;
+            color: var(--text-secondary);
+            cursor: pointer;
+        }
+
+        .checkbox input {
+            width: 16px;
+            height: 16px;
+            cursor: pointer;
+        }
+
+        .button-grid {
+            display: grid;
+            gap: 10px;
+            grid-template-columns: repeat(1, 1fr);
+        }
+
+        button {
+            border: none;
+            border-radius: 12px;
+            padding: 10px;
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+            color: var(--text-primary);
+            background: rgba(76, 141, 255, 0.18);
+            border: 1px solid rgba(76, 141, 255, 0.35);
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 12px 24px rgba(76, 141, 255, 0.25);
+        }
+
+        button.secondary {
+            background: rgba(255, 255, 255, 0.08);
+            border: 1px solid rgba(255, 255, 255, 0.12);
+        }
+
+        .scan-indicator {
+            margin-top: 10px;
+            padding: 10px;
+            border-radius: 12px;
+            background: rgba(255, 255, 255, 0.04);
+            border: 1px dashed rgba(255, 255, 255, 0.08);
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+
+        .scan-indicator.active {
+            color: var(--success);
+            border-color: rgba(61, 214, 140, 0.45);
+            background: rgba(61, 214, 140, 0.08);
+            box-shadow: 0 0 12px rgba(61, 214, 140, 0.25);
+        }
+
+        .modal {
+            position: fixed;
+            inset: 0;
+            background: rgba(5, 8, 15, 0.75);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            padding: 16px;
+            z-index: 100;
+        }
+
+        .modal.show {
+            display: flex;
+        }
+
+        .modal-content {
+            width: 100%;
+            background: #0f131b;
+            border-radius: 16px;
+            padding: 20px;
+            border: 1px solid rgba(76, 141, 255, 0.35);
+            box-shadow: 0 18px 30px rgba(0, 0, 0, 0.5);
+        }
+
+        .modal-content h3 {
+            margin: 0;
+            font-size: 16px;
+        }
+
+        .modal-content p {
+            margin: 10px 0 18px;
+        }
+
+        .modal-actions {
+            display: flex;
+            gap: 10px;
+        }
+
+        .modal-actions button {
+            flex: 1;
+        }
+
+        .modal-actions .primary {
+            background: linear-gradient(135deg, var(--accent), #64a8ff);
+            border-color: transparent;
+        }
+
+        .modal-actions .ghost {
+            background: transparent;
+            border-color: rgba(255, 255, 255, 0.12);
+        }
+
+        .helper-text {
+            font-size: 11px;
+            color: var(--text-secondary);
         }
     </style>
 </head>
 <body>
-    <h3>QA Assist</h3>
-    
-    <!-- Status Icon -->
-    <img id="statusIcon" src="off.png" alt="Status">
-
-    <label>
-        <input type="checkbox" id="toggle">
-        Activate
-    </label>
-
-    <div class="dropdown-container">
-        <div>
-            <h4>Speed</h4>
-            <select id="speed">
-                <option value="1" selected>1x</option>
-                <option value="1.25">1.25x</option>
-                <option value="1.5">1.5x</option>
-                <option value="2">2x</option>
-            </select>
+    <div class="container">
+        <div class="header">
+            <div>
+                <h1>QA Assist</h1>
+                <small>Control Center</small>
+            </div>
+            <div class="status-pill" id="statusPill">
+                <span class="status-dot" id="statusDot"></span>
+                <span id="statusText">Checking...</span>
+            </div>
         </div>
 
-        <div>
-            <h4>Key</h4>
-            <select id="keySelect">
-                <option value="ArrowRight">OAS</option>
-                <option value="ArrowDown" selected>OpWeb</option>
-            </select>
-        </div>
+        <section class="card">
+            <div class="card-header">
+                <h2>Scanning Mode</h2>
+                <span class="badge alert" id="scanningBadge">Standby</span>
+            </div>
+            <p>Enable scanning to automatically monitor and log events as you review footage.</p>
+            <label class="toggle">
+                <input type="checkbox" id="toggle">
+                <span class="toggle-label">Activate Scanning</span>
+            </label>
+            <div class="scan-indicator" id="scanIndicator">Scanning mode is currently inactive.</div>
+        </section>
+
+        <section class="card">
+            <div class="card-header">
+                <h2>Playback &amp; Controls</h2>
+                <span class="badge subtle" id="overrideBadge">No active override</span>
+            </div>
+            <div class="form-row">
+                <label for="speed">Playback Speed</label>
+                <select id="speed">
+                    <option value="1">1x</option>
+                    <option value="1.25">1.25x</option>
+                    <option value="1.5">1.5x</option>
+                    <option value="2">2x</option>
+                </select>
+            </div>
+            <div class="form-row">
+                <label for="keySelect">Key Mapping</label>
+                <select id="keySelect">
+                    <option value="ArrowRight">OAS (➡)</option>
+                    <option value="ArrowDown">OpWeb (⬇)</option>
+                </select>
+                <span class="helper-text">Choose the navigation key for auto-advance behaviour.</span>
+            </div>
+            <div class="form-row">
+                <label class="checkbox">
+                    <input type="checkbox" id="autoPressNext">
+                    <span>Auto Press Next (OpWeb only)</span>
+                </label>
+            </div>
+            <div class="form-row" style="margin-bottom: 0;">
+                <label class="checkbox">
+                    <input type="checkbox" id="removeEyeTracker">
+                    <span>Remove Eye Tracker overlay</span>
+                </label>
+            </div>
+        </section>
+
+        <section class="card">
+            <div class="card-header">
+                <h2>Monitor Profile</h2>
+                <span class="badge subtle">Used for call validation prompts</span>
+            </div>
+            <div class="form-row" style="margin-bottom: 0;">
+                <label for="monitorName">Name</label>
+                <input type="text" id="monitorName" placeholder="Enter your name" autocomplete="off">
+            </div>
+        </section>
+
+        <section class="card">
+            <div class="card-header">
+                <h2>Tools &amp; Pages</h2>
+            </div>
+            <div class="button-grid">
+                <button id="viewLogs">Open Event Log</button>
+                <button id="openSettings" class="secondary">Settings</button>
+                <button id="openOverrides" class="secondary">Site Overrides</button>
+                <button id="openSiteInfo" class="secondary">Site Info</button>
+            </div>
+        </section>
     </div>
 
-    <label>
-        <input type="checkbox" id="autoPressNext">
-        Auto Press Next (OpWeb only)
-    </label>
-
-    <div style="margin-top: 8px;"></div>
-
-    <label>
-        <input type="checkbox" id="removeEyeTracker">
-        Remove Eye Tracker
-    </label>
-
-    <p id="status">Status: <span id="statusText">Checking...</span></p>
-
-    <button id="viewLogs">View Logs</button>
+    <div class="modal" id="scanConfirm">
+        <div class="modal-content">
+            <h3>Enable Scanning Mode?</h3>
+            <p>Scanning mode will watch for new videos, adjust playback, and record each event automatically. You can disable this at any time.</p>
+            <div class="modal-actions">
+                <button class="primary" id="confirmScan">Start Scanning</button>
+                <button class="ghost" id="cancelScan">Cancel</button>
+            </div>
+        </div>
+    </div>
 
     <script src="popup.js"></script>
 </body>

--- a/popup.js
+++ b/popup.js
@@ -1,106 +1,212 @@
-document.addEventListener("DOMContentLoaded", function () {
-    let toggle = document.getElementById("toggle");
-    let speedSelect = document.getElementById("speed");
-    let keySelect = document.getElementById("keySelect");
-    let statusText = document.getElementById("statusText");
-    let statusIcon = document.getElementById("statusIcon"); // 48x48px Image for status
-    let autoPressNextToggle = document.getElementById("autoPressNext");
-    let removeEyeTrackerToggle = document.getElementById("removeEyeTracker");
-    let viewLogsButton = document.getElementById("viewLogs");
-    
-    // Load stored settings
-    chrome.storage.sync.get(["enabled", "playbackSpeed", "pressKey", "autoPressNext", "removeEyeTracker"], function (data) {
-        console.log("🔄 Loaded settings:", data);
+document.addEventListener("DOMContentLoaded", () => {
+    const toggle = document.getElementById("toggle");
+    const speedSelect = document.getElementById("speed");
+    const keySelect = document.getElementById("keySelect");
+    const statusText = document.getElementById("statusText");
+    const statusDot = document.getElementById("statusDot");
+    const scanningBadge = document.getElementById("scanningBadge");
+    const scanIndicator = document.getElementById("scanIndicator");
+    const autoPressNextToggle = document.getElementById("autoPressNext");
+    const removeEyeTrackerToggle = document.getElementById("removeEyeTracker");
+    const monitorNameInput = document.getElementById("monitorName");
+    const viewLogsButton = document.getElementById("viewLogs");
+    const openOverridesButton = document.getElementById("openOverrides");
+    const openSiteInfoButton = document.getElementById("openSiteInfo");
+    const openSettingsButton = document.getElementById("openSettings");
+    const overrideBadge = document.getElementById("overrideBadge");
 
-        toggle.checked = data.enabled ?? false;
-        speedSelect.value = data.playbackSpeed || "1"; 
-        keySelect.value = data.pressKey || "ArrowDown"; 
-        autoPressNextToggle.checked = data.autoPressNext ?? false;
-        removeEyeTrackerToggle.checked = data.removeEyeTracker ?? false;
+    const scanConfirmModal = document.getElementById("scanConfirm");
+    const confirmScanButton = document.getElementById("confirmScan");
+    const cancelScanButton = document.getElementById("cancelScan");
 
-        updateStatus(toggle.checked);
-    });
+    let currentEnabledState = false;
+    let cachedOverrides = [];
 
-    // Function to update status text and icon
-    function updateStatus(isEnabled) {
-        statusText.textContent = isEnabled ? "Enabled" : "Disabled";
-        statusText.style.color = isEnabled ? "green" : "red";
-        statusIcon.src = isEnabled ? "on.png" : "off.png"; // Change icon
+    function findOverrideForUrl(url, overrides) {
+        if (!url || !Array.isArray(overrides)) {
+            return null;
+        }
+
+        let host = "";
+        try {
+            host = new URL(url).hostname.toLowerCase();
+        } catch (error) {
+            host = url.toLowerCase();
+        }
+
+        return (
+            overrides.find((override) => {
+                if (!override || !override.pattern) {
+                    return false;
+                }
+
+                const pattern = String(override.pattern).toLowerCase();
+                return host === pattern || host.endsWith(`.${pattern}`) || url.toLowerCase().includes(pattern);
+            }) || null
+        );
     }
 
-    // Toggle switch event
-    toggle.addEventListener("change", function () {
-        let isEnabled = toggle.checked;
-        console.log("🔘 Toggling state to:", isEnabled);
+    function updateOverrideBadge(overrides) {
+        chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+            if (!tabs.length) {
+                return;
+            }
+
+            const activeTab = tabs[0];
+            const override = findOverrideForUrl(activeTab.url, overrides);
+
+            if (override) {
+                overrideBadge.textContent = override.name ? `Override: ${override.name}` : "Override active";
+                overrideBadge.classList.add("active");
+                overrideBadge.classList.remove("subtle");
+            } else {
+                overrideBadge.textContent = "No active override";
+                overrideBadge.classList.remove("active");
+                overrideBadge.classList.add("subtle");
+            }
+        });
+    }
+
+    function updateStatusVisuals(isEnabled) {
+        statusText.textContent = isEnabled ? "Scanning" : "Standby";
+        statusText.style.color = isEnabled ? "var(--success)" : "var(--warning)";
+        statusDot.style.background = isEnabled ? "var(--success)" : "var(--warning)";
+        statusDot.style.boxShadow = isEnabled
+            ? "0 0 10px rgba(61, 214, 140, 0.7)"
+            : "0 0 8px rgba(246, 201, 95, 0.6)";
+
+        scanningBadge.textContent = isEnabled ? "Active" : "Standby";
+        scanningBadge.classList.toggle("active", isEnabled);
+        scanningBadge.classList.toggle("alert", !isEnabled);
+
+        scanIndicator.textContent = isEnabled
+            ? "Scanning mode is actively monitoring for new events."
+            : "Scanning mode is currently inactive.";
+        scanIndicator.classList.toggle("active", isEnabled);
+    }
+
+    function sendMessageToActiveTab(payload) {
+        chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+            if (!tabs.length) {
+                return;
+            }
+            chrome.tabs.sendMessage(tabs[0].id, payload, () => chrome.runtime.lastError);
+        });
+    }
+
+    function setEnabledState(isEnabled) {
+        currentEnabledState = isEnabled;
+        toggle.checked = isEnabled;
+        updateStatusVisuals(isEnabled);
 
         chrome.storage.sync.set({ enabled: isEnabled }, () => {
-            updateStatus(isEnabled);
-            chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-                if (tabs.length > 0) {
-                    chrome.tabs.sendMessage(tabs[0].id, { enabled: isEnabled });
-                }
-            });
+            sendMessageToActiveTab({ enabled: isEnabled });
         });
+
+        chrome.runtime.sendMessage({ type: "updateBrowserIcon", enabled: isEnabled });
+    }
+
+    function openScanConfirm() {
+        scanConfirmModal.classList.add("show");
+    }
+
+    function closeScanConfirm() {
+        scanConfirmModal.classList.remove("show");
+    }
+
+    chrome.storage.sync.get(
+        ["enabled", "playbackSpeed", "pressKey", "autoPressNext", "removeEyeTracker", "monitorName", "siteOverrides"],
+        (data) => {
+            currentEnabledState = data.enabled ?? false;
+            toggle.checked = currentEnabledState;
+            speedSelect.value = data.playbackSpeed || "1";
+            keySelect.value = data.pressKey || "ArrowDown";
+            autoPressNextToggle.checked = data.autoPressNext ?? false;
+            removeEyeTrackerToggle.checked = data.removeEyeTracker ?? false;
+            monitorNameInput.value = data.monitorName || "";
+            cachedOverrides = Array.isArray(data.siteOverrides) ? data.siteOverrides : [];
+
+            updateStatusVisuals(currentEnabledState);
+            updateOverrideBadge(cachedOverrides);
+            sendMessageToActiveTab({ siteOverrides: cachedOverrides });
+            chrome.runtime.sendMessage({ type: "updateBrowserIcon", enabled: currentEnabledState });
+        },
+    );
+
+    toggle.addEventListener("change", () => {
+        const desiredState = toggle.checked;
+        if (desiredState && !currentEnabledState) {
+            toggle.checked = currentEnabledState;
+            openScanConfirm();
+            return;
+        }
+
+        setEnabledState(desiredState);
     });
 
-    // Auto Press Next List Toggle
-    autoPressNextToggle.addEventListener("change", function () {
-        let isEnabled = autoPressNextToggle.checked;
-        console.log("🔄 Auto Press Next List:", isEnabled);
+    confirmScanButton.addEventListener("click", () => {
+        closeScanConfirm();
+        setEnabledState(true);
+    });
 
+    cancelScanButton.addEventListener("click", () => {
+        closeScanConfirm();
+        setEnabledState(false);
+    });
+
+    autoPressNextToggle.addEventListener("change", () => {
+        const isEnabled = autoPressNextToggle.checked;
         chrome.storage.sync.set({ autoPressNext: isEnabled }, () => {
-            chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-                if (tabs.length > 0) {
-                    chrome.tabs.sendMessage(tabs[0].id, { autoPressNext: isEnabled });
-                }
-            });
+            sendMessageToActiveTab({ autoPressNext: isEnabled });
         });
     });
 
-    // Remove Eye Tracker Toggle
-    removeEyeTrackerToggle.addEventListener("change", function () {
-        let isEnabled = removeEyeTrackerToggle.checked;
-        console.log("👀 Remove Eye Tracker:", isEnabled);
-
+    removeEyeTrackerToggle.addEventListener("change", () => {
+        const isEnabled = removeEyeTrackerToggle.checked;
         chrome.storage.sync.set({ removeEyeTracker: isEnabled }, () => {
-            chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-                if (tabs.length > 0) {
-                    chrome.tabs.sendMessage(tabs[0].id, { removeEyeTracker: isEnabled });
-                }
-            });
+            sendMessageToActiveTab({ removeEyeTracker: isEnabled });
         });
     });
 
-    // Speed selection event
-    speedSelect.addEventListener("change", function () {
-        let selectedSpeed = speedSelect.value;
-        console.log("⚡ Speed changed to:", selectedSpeed);
-
+    speedSelect.addEventListener("change", () => {
+        const selectedSpeed = speedSelect.value;
         chrome.storage.sync.set({ playbackSpeed: selectedSpeed }, () => {
-            chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-                if (tabs.length > 0) {
-                    chrome.tabs.sendMessage(tabs[0].id, { playbackSpeed: selectedSpeed });
-                }
-            });
+            sendMessageToActiveTab({ playbackSpeed: selectedSpeed });
         });
     });
 
-    // Key selection event
-    keySelect.addEventListener("change", function () {
-        let selectedKey = keySelect.value;
-        console.log("🎯 Key changed to:", selectedKey);
-
+    keySelect.addEventListener("change", () => {
+        const selectedKey = keySelect.value;
         chrome.storage.sync.set({ pressKey: selectedKey }, () => {
-            chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-                if (tabs.length > 0) {
-                    chrome.tabs.sendMessage(tabs[0].id, { pressKey: selectedKey });
-                }
-            });
+            sendMessageToActiveTab({ pressKey: selectedKey });
         });
     });
 
-    // Open log.html when clicking "View Logs" button
-    viewLogsButton.addEventListener("click", function () {
+    monitorNameInput.addEventListener("blur", () => {
+        const name = monitorNameInput.value.trim();
+        chrome.storage.sync.set({ monitorName: name });
+    });
+
+    monitorNameInput.addEventListener("keydown", (event) => {
+        if (event.key === "Enter") {
+            event.preventDefault();
+            monitorNameInput.blur();
+        }
+    });
+
+    viewLogsButton.addEventListener("click", () => {
         chrome.tabs.create({ url: chrome.runtime.getURL("log.html") });
+    });
+
+    openOverridesButton.addEventListener("click", () => {
+        chrome.tabs.create({ url: chrome.runtime.getURL("site-overrides.html") });
+    });
+
+    openSiteInfoButton.addEventListener("click", () => {
+        chrome.tabs.create({ url: chrome.runtime.getURL("site-info.html") });
+    });
+
+    openSettingsButton.addEventListener("click", () => {
+        chrome.tabs.create({ url: chrome.runtime.getURL("settings.html") });
     });
 });

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>QA Assist · Settings</title>
+    <style>
+        :root {
+            color-scheme: dark;
+            --bg: #080c14;
+            --card: #131a27;
+            --border: #1f2838;
+            --text: #f3f5ff;
+            --muted: #909bb8;
+            --accent: #4c8dff;
+            --accent-soft: rgba(76, 141, 255, 0.15);
+            --danger: #ff5c8d;
+            --success: #3dd68c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            padding: 36px 40px 48px;
+            font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+            background: radial-gradient(circle at top right, rgba(76, 141, 255, 0.12), transparent 55%), var(--bg);
+            color: var(--text);
+        }
+
+        .nav-bar {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+            margin-bottom: 28px;
+        }
+
+        .nav-link {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 10px 16px;
+            border-radius: 999px;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            background: rgba(255, 255, 255, 0.05);
+            color: var(--muted);
+            font-size: 13px;
+            font-weight: 600;
+            text-decoration: none;
+            transition: transform 0.15s ease, box-shadow 0.15s ease, color 0.15s ease;
+        }
+
+        .nav-link:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+        }
+
+        .nav-link.active {
+            color: #fff;
+            border-color: rgba(76, 141, 255, 0.35);
+            background: linear-gradient(135deg, rgba(76, 141, 255, 0.32), rgba(17, 21, 34, 0.85));
+            box-shadow: 0 18px 36px rgba(76, 141, 255, 0.28);
+        }
+
+        header {
+            margin-bottom: 28px;
+        }
+
+        h1 {
+            margin: 0;
+            font-size: 30px;
+            letter-spacing: 0.02em;
+        }
+
+        p.lead {
+            margin: 10px 0 0;
+            color: var(--muted);
+            max-width: 640px;
+        }
+
+        .card {
+            background: var(--card);
+            border-radius: 20px;
+            border: 1px solid var(--border);
+            padding: 28px;
+            margin-bottom: 24px;
+            box-shadow: 0 32px 60px rgba(0, 0, 0, 0.35);
+        }
+
+        .card-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 18px;
+        }
+
+        .card-header h2 {
+            margin: 0;
+            font-size: 22px;
+        }
+
+        .status-indicator {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 6px 12px;
+            border-radius: 999px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(255, 255, 255, 0.04);
+            font-size: 12px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--muted);
+        }
+
+        .status-indicator.active {
+            color: var(--success);
+            border-color: rgba(61, 214, 140, 0.35);
+            background: rgba(61, 214, 140, 0.12);
+        }
+
+        .toggle {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            background: rgba(255, 255, 255, 0.05);
+            border-radius: 14px;
+            padding: 14px 18px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+        }
+
+        .toggle span {
+            font-size: 13px;
+            color: var(--muted);
+        }
+
+        .switch {
+            position: relative;
+            width: 46px;
+            height: 24px;
+        }
+
+        .switch input {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+
+        .slider {
+            position: absolute;
+            cursor: pointer;
+            inset: 0;
+            background: rgba(255, 255, 255, 0.18);
+            border-radius: 999px;
+            transition: background 0.2s ease;
+        }
+
+        .slider::before {
+            content: "";
+            position: absolute;
+            height: 18px;
+            width: 18px;
+            left: 3px;
+            top: 3px;
+            border-radius: 50%;
+            background: #0f141e;
+            transition: transform 0.2s ease;
+        }
+
+        .switch input:checked + .slider {
+            background: linear-gradient(135deg, var(--accent), #6aa2ff);
+            box-shadow: 0 0 12px rgba(76, 141, 255, 0.35);
+        }
+
+        .switch input:checked + .slider::before {
+            transform: translateX(22px);
+            background: #fff;
+        }
+
+        .form-grid {
+            display: grid;
+            gap: 18px;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+
+        label {
+            display: block;
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--muted);
+            margin-bottom: 6px;
+        }
+
+        select,
+        input[type="text"],
+        input[type="number"] {
+            width: 100%;
+            padding: 10px 12px;
+            border-radius: 12px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(10, 14, 22, 0.85);
+            color: var(--text);
+            font-size: 14px;
+        }
+
+        .checkbox-row {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        .checkbox {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 13px;
+            color: var(--muted);
+            cursor: pointer;
+        }
+
+        .checkbox input {
+            width: 16px;
+            height: 16px;
+            cursor: pointer;
+        }
+
+        .helper-text {
+            font-size: 12px;
+            color: var(--muted);
+            margin-top: 4px;
+        }
+
+        @media (max-width: 900px) {
+            body {
+                padding: 24px;
+            }
+
+            .card {
+                padding: 24px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <nav class="nav-bar">
+        <a class="nav-link" href="log.html">Event Log</a>
+        <a class="nav-link active" href="settings.html">Settings</a>
+        <a class="nav-link" href="site-info.html">Site Info</a>
+        <a class="nav-link" href="site-overrides.html">Site Overrides</a>
+    </nav>
+    <header>
+        <h1>QA Assist — Settings</h1>
+        <p class="lead">Configure scanning behaviour, playback controls, and your monitor profile. These preferences are shared with the popup
+            for quick adjustments.</p>
+    </header>
+
+    <section class="card">
+        <div class="card-header">
+            <h2>Scanning Mode</h2>
+            <span class="status-indicator" id="scanningStatus">Standby</span>
+        </div>
+        <div class="toggle">
+            <span>Enable automatic scanning and event logging</span>
+            <label class="switch">
+                <input type="checkbox" id="enableScanning">
+                <span class="slider"></span>
+            </label>
+        </div>
+        <p class="helper-text">When enabled, QA Assist will monitor supported pages, adjust playback, and capture events automatically.</p>
+    </section>
+
+    <section class="card">
+        <div class="card-header">
+            <h2>Playback &amp; Controls</h2>
+        </div>
+        <div class="form-grid">
+            <div>
+                <label for="playbackSpeed">Playback Speed</label>
+                <select id="playbackSpeed">
+                    <option value="1">1x</option>
+                    <option value="1.25">1.25x</option>
+                    <option value="1.5">1.5x</option>
+                    <option value="2">2x</option>
+                </select>
+            </div>
+            <div>
+                <label for="pressKey">Key Mapping</label>
+                <select id="pressKey">
+                    <option value="ArrowRight">OAS (➡)</option>
+                    <option value="ArrowDown">OpWeb (⬇)</option>
+                </select>
+                <p class="helper-text">Determines which navigation key is used for automatic progression.</p>
+            </div>
+        </div>
+        <div class="checkbox-row">
+            <label class="checkbox">
+                <input type="checkbox" id="autoPressNext">
+                <span>Auto press next when scanning OpWeb events</span>
+            </label>
+            <label class="checkbox">
+                <input type="checkbox" id="removeEyeTracker">
+                <span>Hide eye tracker overlay during playback</span>
+            </label>
+        </div>
+    </section>
+
+    <section class="card">
+        <div class="card-header">
+            <h2>Monitor Profile</h2>
+        </div>
+        <div class="form-grid">
+            <div>
+                <label for="monitorName">Monitor Name</label>
+                <input type="text" id="monitorName" placeholder="Enter your name" autocomplete="off">
+                <p class="helper-text">Used when confirming call validation details.</p>
+            </div>
+        </div>
+    </section>
+
+    <script src="settings.js"></script>
+</body>
+</html>

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,95 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const scanningToggle = document.getElementById("enableScanning");
+    const scanningStatus = document.getElementById("scanningStatus");
+    const playbackSelect = document.getElementById("playbackSpeed");
+    const keySelect = document.getElementById("pressKey");
+    const autoPressNextToggle = document.getElementById("autoPressNext");
+    const removeEyeTrackerToggle = document.getElementById("removeEyeTracker");
+    const monitorInput = document.getElementById("monitorName");
+
+    function sendMessageToActiveTab(payload) {
+        chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+            if (!tabs.length) {
+                return;
+            }
+            chrome.tabs.sendMessage(tabs[0].id, payload, () => chrome.runtime.lastError);
+        });
+    }
+
+    function updateScanningStatus(isEnabled) {
+        scanningStatus.textContent = isEnabled ? "Active" : "Standby";
+        scanningStatus.classList.toggle("active", isEnabled);
+    }
+
+    function setEnabledState(isEnabled) {
+        scanningToggle.checked = isEnabled;
+        updateScanningStatus(isEnabled);
+        chrome.storage.sync.set({ enabled: isEnabled }, () => {
+            sendMessageToActiveTab({ enabled: isEnabled });
+            chrome.runtime.sendMessage({ type: "updateBrowserIcon", enabled: isEnabled });
+        });
+    }
+
+    chrome.storage.sync.get(
+        ["enabled", "playbackSpeed", "pressKey", "autoPressNext", "removeEyeTracker", "monitorName", "siteOverrides"],
+        (data) => {
+            const enabled = data.enabled ?? false;
+            scanningToggle.checked = enabled;
+            updateScanningStatus(enabled);
+
+            playbackSelect.value = data.playbackSpeed || "1";
+            keySelect.value = data.pressKey || "ArrowDown";
+            autoPressNextToggle.checked = data.autoPressNext ?? false;
+            removeEyeTrackerToggle.checked = data.removeEyeTracker ?? false;
+            monitorInput.value = data.monitorName || "";
+
+            sendMessageToActiveTab({ siteOverrides: Array.isArray(data.siteOverrides) ? data.siteOverrides : [] });
+        },
+    );
+
+    scanningToggle.addEventListener("change", () => {
+        const isEnabled = scanningToggle.checked;
+        setEnabledState(isEnabled);
+    });
+
+    playbackSelect.addEventListener("change", () => {
+        const speed = playbackSelect.value;
+        chrome.storage.sync.set({ playbackSpeed: speed }, () => {
+            sendMessageToActiveTab({ playbackSpeed: speed });
+        });
+    });
+
+    keySelect.addEventListener("change", () => {
+        const key = keySelect.value;
+        chrome.storage.sync.set({ pressKey: key }, () => {
+            sendMessageToActiveTab({ pressKey: key });
+        });
+    });
+
+    autoPressNextToggle.addEventListener("change", () => {
+        const isEnabled = autoPressNextToggle.checked;
+        chrome.storage.sync.set({ autoPressNext: isEnabled }, () => {
+            sendMessageToActiveTab({ autoPressNext: isEnabled });
+        });
+    });
+
+    removeEyeTrackerToggle.addEventListener("change", () => {
+        const isEnabled = removeEyeTrackerToggle.checked;
+        chrome.storage.sync.set({ removeEyeTracker: isEnabled }, () => {
+            sendMessageToActiveTab({ removeEyeTracker: isEnabled });
+        });
+    });
+
+    function persistMonitorName() {
+        const name = monitorInput.value.trim();
+        chrome.storage.sync.set({ monitorName: name });
+    }
+
+    monitorInput.addEventListener("blur", persistMonitorName);
+    monitorInput.addEventListener("keydown", (event) => {
+        if (event.key === "Enter") {
+            event.preventDefault();
+            monitorInput.blur();
+        }
+    });
+});

--- a/site-info.html
+++ b/site-info.html
@@ -1,0 +1,305 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>QA Assist · Site Info</title>
+    <style>
+        :root {
+            color-scheme: dark;
+            --bg: #090d14;
+            --card: #131927;
+            --border: #1f2738;
+            --text: #f4f6ff;
+            --muted: #8e99b9;
+            --accent: #4c8dff;
+            --accent-soft: rgba(76, 141, 255, 0.15);
+            --danger: #ff5c8d;
+            --success: #3dd68c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            padding: 36px 40px 48px;
+            font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(160deg, rgba(76, 141, 255, 0.08), transparent 55%), var(--bg);
+            color: var(--text);
+        }
+
+        .nav-bar {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+            margin-bottom: 28px;
+        }
+
+        .nav-link {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 10px 16px;
+            border-radius: 999px;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            background: rgba(255, 255, 255, 0.05);
+            color: var(--muted);
+            font-size: 13px;
+            font-weight: 600;
+            text-decoration: none;
+            transition: transform 0.15s ease, box-shadow 0.15s ease, color 0.15s ease;
+        }
+
+        .nav-link:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+        }
+
+        .nav-link.active {
+            color: #fff;
+            border-color: rgba(76, 141, 255, 0.35);
+            background: linear-gradient(135deg, rgba(76, 141, 255, 0.32), rgba(17, 21, 34, 0.85));
+            box-shadow: 0 18px 36px rgba(76, 141, 255, 0.28);
+        }
+
+        h1 {
+            margin: 0;
+            font-size: 30px;
+            letter-spacing: 0.02em;
+        }
+
+        p {
+            color: var(--muted);
+            font-size: 15px;
+            margin: 10px 0 26px;
+            max-width: 680px;
+        }
+
+        .card {
+            background: var(--card);
+            border-radius: 20px;
+            border: 1px solid var(--border);
+            padding: 28px;
+            margin-bottom: 28px;
+            box-shadow: 0 40px 70px rgba(0, 0, 0, 0.35);
+        }
+
+        .card-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 20px;
+        }
+
+        .card-header h2 {
+            margin: 0;
+            font-size: 22px;
+        }
+
+        .tag {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 12px;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.06);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            color: var(--muted);
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 14px;
+        }
+
+        th,
+        td {
+            padding: 14px 16px;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+            text-align: left;
+        }
+
+        th {
+            color: var(--muted);
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            font-size: 12px;
+        }
+
+        tbody tr:hover {
+            background: rgba(76, 141, 255, 0.07);
+        }
+
+        .muted {
+            color: var(--muted);
+            font-size: 12px;
+        }
+
+        .actions {
+            display: flex;
+            gap: 10px;
+        }
+
+        button {
+            border: none;
+            border-radius: 12px;
+            padding: 10px 14px;
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        button.primary {
+            background: linear-gradient(135deg, var(--accent), #6aa2ff);
+            color: #fff;
+            box-shadow: 0 12px 24px rgba(76, 141, 255, 0.35);
+        }
+
+        button.ghost {
+            background: rgba(255, 255, 255, 0.06);
+            color: var(--muted);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        button.danger {
+            background: rgba(255, 92, 141, 0.12);
+            color: var(--danger);
+            border: 1px solid rgba(255, 92, 141, 0.35);
+        }
+
+        button:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+        }
+
+        .form-grid {
+            display: grid;
+            gap: 16px;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+
+        label {
+            display: block;
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--muted);
+            margin-bottom: 6px;
+        }
+
+        input[type="text"] {
+            width: 100%;
+            padding: 10px 12px;
+            border-radius: 12px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(10, 14, 22, 0.85);
+            color: var(--text);
+            font-size: 14px;
+        }
+
+        .form-footer {
+            margin-top: 18px;
+            display: flex;
+            gap: 12px;
+            justify-content: flex-end;
+        }
+
+        .empty-state {
+            text-align: center;
+            padding: 40px 20px;
+            color: var(--muted);
+        }
+
+        .toast {
+            position: fixed;
+            bottom: 24px;
+            right: 24px;
+            background: rgba(11, 15, 25, 0.9);
+            padding: 14px 18px;
+            border-radius: 12px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            color: var(--text);
+            font-size: 13px;
+            display: none;
+            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+        }
+
+        .toast.show {
+            display: block;
+        }
+
+        @media (max-width: 900px) {
+            body {
+                padding: 24px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <nav class="nav-bar">
+        <a class="nav-link" href="log.html">Event Log</a>
+        <a class="nav-link" href="settings.html">Settings</a>
+        <a class="nav-link active" href="site-info.html">Site Info</a>
+        <a class="nav-link" href="site-overrides.html">Site Overrides</a>
+    </nav>
+    <header>
+        <h1>QA Assist — Site Info</h1>
+        <p>Manage the site aliases used across QA Assist. Each entry maps a human-readable site name to the address or IP detected in the event logs.</p>
+    </header>
+
+    <section class="card">
+        <div class="card-header">
+            <h2>Saved Sites</h2>
+            <span class="tag" id="siteCount">0 sites</span>
+        </div>
+        <div class="table-wrapper">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Address</th>
+                        <th>Match Value</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody id="siteTableBody">
+                    <tr class="empty-state">
+                        <td colspan="4">No sites have been added yet.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <section class="card">
+        <div class="card-header">
+            <h2>Add Site</h2>
+            <span class="tag">New entry</span>
+        </div>
+        <div class="form-grid">
+            <div>
+                <label for="siteNameInput">Site Name</label>
+                <input type="text" id="siteNameInput" placeholder="e.g., Maules Creek">
+            </div>
+            <div>
+                <label for="siteAddressInput">Address / URL</label>
+                <input type="text" id="siteAddressInput" placeholder="e.g., http://10.20.250.1/">
+            </div>
+        </div>
+        <div class="form-footer">
+            <button class="ghost" id="clearForm">Clear</button>
+            <button class="primary" id="addSite">Add Site</button>
+        </div>
+    </section>
+
+    <div class="toast" id="toast"></div>
+
+    <script src="site-info.js"></script>
+</body>
+</html>

--- a/site-info.js
+++ b/site-info.js
@@ -1,0 +1,280 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const siteTableBody = document.getElementById("siteTableBody");
+    const siteCount = document.getElementById("siteCount");
+    const siteNameInput = document.getElementById("siteNameInput");
+    const siteAddressInput = document.getElementById("siteAddressInput");
+    const addSiteButton = document.getElementById("addSite");
+    const clearFormButton = document.getElementById("clearForm");
+    const toast = document.getElementById("toast");
+
+    let sites = [];
+    let toastTimeout = null;
+
+    function generateId() {
+        if (typeof crypto !== "undefined" && crypto.randomUUID) {
+            return crypto.randomUUID();
+        }
+        return `site-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+    }
+
+    function deriveMatchValue(address) {
+        if (!address) {
+            return "";
+        }
+
+        let cleaned = address.trim();
+        cleaned = cleaned.replace(/[()]/g, "");
+
+        if (cleaned.startsWith("http://") || cleaned.startsWith("https://")) {
+            try {
+                const url = new URL(cleaned);
+                return url.hostname.toLowerCase();
+            } catch (error) {
+                cleaned = cleaned.replace(/^https?:\/\//, "");
+            }
+        }
+
+        cleaned = cleaned.replace(/^https?:\/\//, "");
+        cleaned = cleaned.replace(/\/$/, "");
+        cleaned = cleaned.replace(/:.*/, "");
+
+        return cleaned.toLowerCase();
+    }
+
+    function ensureSiteShape(site) {
+        if (!site) {
+            return null;
+        }
+
+        const shaped = { ...site };
+        shaped.id = shaped.id || generateId();
+        shaped.name = (shaped.name || "").trim();
+        shaped.address = (shaped.address || "").trim();
+        shaped.matchValue = (shaped.matchValue || deriveMatchValue(shaped.address || shaped.name)).trim();
+        return shaped.matchValue ? shaped : null;
+    }
+
+    function showToast(message) {
+        if (!toast) {
+            return;
+        }
+        toast.textContent = message;
+        toast.classList.add("show");
+
+        if (toastTimeout) {
+            clearTimeout(toastTimeout);
+        }
+
+        toastTimeout = setTimeout(() => {
+            toast.classList.remove("show");
+        }, 2200);
+    }
+
+    function saveSites() {
+        chrome.storage.sync.set({ siteInfo: sites });
+    }
+
+    function resetForm() {
+        siteNameInput.value = "";
+        siteAddressInput.value = "";
+    }
+
+    function renderSites() {
+        siteTableBody.innerHTML = "";
+        siteCount.textContent = `${sites.length} site${sites.length === 1 ? "" : "s"}`;
+
+        if (!sites.length) {
+            const emptyRow = document.createElement("tr");
+            emptyRow.className = "empty-state";
+            const cell = document.createElement("td");
+            cell.colSpan = 4;
+            cell.textContent = "No sites have been added yet.";
+            emptyRow.appendChild(cell);
+            siteTableBody.appendChild(emptyRow);
+            return;
+        }
+
+        sites
+            .slice()
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .forEach((site) => {
+                const row = document.createElement("tr");
+                row.dataset.id = site.id;
+
+                const nameCell = document.createElement("td");
+                nameCell.innerHTML = `<div>${site.name}</div><div class="muted">ID: ${site.matchValue}</div>`;
+
+                const addressCell = document.createElement("td");
+                addressCell.textContent = site.address;
+
+                const matchCell = document.createElement("td");
+                matchCell.textContent = site.matchValue;
+
+                const actionsCell = document.createElement("td");
+                actionsCell.className = "actions";
+
+                const editButton = document.createElement("button");
+                editButton.className = "ghost";
+                editButton.textContent = "Edit";
+                editButton.addEventListener("click", () => enterEditMode(row, site));
+
+                const deleteButton = document.createElement("button");
+                deleteButton.className = "danger";
+                deleteButton.textContent = "Delete";
+                deleteButton.addEventListener("click", () => deleteSite(site.id));
+
+                actionsCell.appendChild(editButton);
+                actionsCell.appendChild(deleteButton);
+
+                row.appendChild(nameCell);
+                row.appendChild(addressCell);
+                row.appendChild(matchCell);
+                row.appendChild(actionsCell);
+
+                siteTableBody.appendChild(row);
+            });
+    }
+
+    function deleteSite(id) {
+        const index = sites.findIndex((site) => site.id === id);
+        if (index === -1) {
+            return;
+        }
+
+        sites.splice(index, 1);
+        saveSites();
+        renderSites();
+        showToast("Site removed");
+    }
+
+    function enterEditMode(row, site) {
+        row.innerHTML = "";
+
+        const nameCell = document.createElement("td");
+        const nameInput = document.createElement("input");
+        nameInput.type = "text";
+        nameInput.value = site.name;
+        nameCell.appendChild(nameInput);
+
+        const addressCell = document.createElement("td");
+        const addressInput = document.createElement("input");
+        addressInput.type = "text";
+        addressInput.value = site.address;
+        addressCell.appendChild(addressInput);
+
+        const matchCell = document.createElement("td");
+        matchCell.textContent = site.matchValue;
+
+        const actionsCell = document.createElement("td");
+        actionsCell.className = "actions";
+
+        const saveButton = document.createElement("button");
+        saveButton.className = "primary";
+        saveButton.textContent = "Save";
+        saveButton.addEventListener("click", () => {
+            const newName = nameInput.value.trim();
+            const newAddress = addressInput.value.trim();
+
+            if (!newName || !newAddress) {
+                showToast("Provide both a name and address.");
+                return;
+            }
+
+            const newMatchValue = deriveMatchValue(newAddress) || deriveMatchValue(newName);
+            if (!newMatchValue) {
+                showToast("Unable to derive a match value from the address.");
+                return;
+            }
+
+            const duplicate = sites.some((entry) => entry.id !== site.id && entry.matchValue === newMatchValue);
+            if (duplicate) {
+                showToast("Another site already uses this address.");
+                return;
+            }
+
+            site.name = newName;
+            site.address = newAddress;
+            site.matchValue = newMatchValue;
+
+            saveSites();
+            renderSites();
+            showToast("Site updated");
+        });
+
+        const cancelButton = document.createElement("button");
+        cancelButton.className = "ghost";
+        cancelButton.textContent = "Cancel";
+        cancelButton.addEventListener("click", () => renderSites());
+
+        actionsCell.appendChild(saveButton);
+        actionsCell.appendChild(cancelButton);
+
+        row.appendChild(nameCell);
+        row.appendChild(addressCell);
+        row.appendChild(matchCell);
+        row.appendChild(actionsCell);
+
+        nameInput.focus();
+    }
+
+    function addSite() {
+        const name = siteNameInput.value.trim();
+        const address = siteAddressInput.value.trim();
+
+        if (!name || !address) {
+            showToast("Provide both a name and address.");
+            return;
+        }
+
+        const matchValue = deriveMatchValue(address) || deriveMatchValue(name);
+        if (!matchValue) {
+            showToast("Unable to derive a match value from the address.");
+            return;
+        }
+
+        const duplicate = sites.some((site) => site.matchValue === matchValue);
+        if (duplicate) {
+            showToast("A site with this address already exists.");
+            return;
+        }
+
+        const newSite = ensureSiteShape({ id: generateId(), name, address, matchValue });
+        if (!newSite) {
+            showToast("The entry could not be created.");
+            return;
+        }
+
+        sites.push(newSite);
+        saveSites();
+        renderSites();
+        resetForm();
+        showToast("Site added");
+    }
+
+    addSiteButton.addEventListener("click", addSite);
+    siteAddressInput.addEventListener("keydown", (event) => {
+        if (event.key === "Enter") {
+            event.preventDefault();
+            addSite();
+        }
+    });
+
+    siteNameInput.addEventListener("keydown", (event) => {
+        if (event.key === "Enter") {
+            event.preventDefault();
+            addSite();
+        }
+    });
+
+    clearFormButton.addEventListener("click", () => {
+        resetForm();
+    });
+
+    chrome.storage.sync.get("siteInfo", (data) => {
+        const loadedSites = Array.isArray(data.siteInfo) ? data.siteInfo : [];
+        sites = loadedSites
+            .map((site) => ensureSiteShape(site))
+            .filter(Boolean);
+        renderSites();
+    });
+});

--- a/site-overrides.html
+++ b/site-overrides.html
@@ -1,0 +1,551 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>QA Assist · Site Overrides</title>
+    <style>
+        :root {
+            color-scheme: dark;
+            --bg: #070b13;
+            --card: #121927;
+            --border: #1c2434;
+            --text: #f2f5ff;
+            --muted: #8a96b5;
+            --accent: #4c8dff;
+            --accent-glow: rgba(76, 141, 255, 0.28);
+            --danger: #ff5c8d;
+            --success: #3dd68c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            padding: 38px 42px 60px;
+            font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+            background: radial-gradient(circle at top right, rgba(76, 141, 255, 0.12), transparent 55%), var(--bg);
+            color: var(--text);
+        }
+
+        .nav-bar {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+            margin-bottom: 32px;
+        }
+
+        .nav-link {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 10px 16px;
+            border-radius: 999px;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            background: rgba(255, 255, 255, 0.05);
+            color: var(--muted);
+            font-size: 13px;
+            font-weight: 600;
+            text-decoration: none;
+            transition: transform 0.15s ease, box-shadow 0.15s ease, color 0.15s ease;
+        }
+
+        .nav-link:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+        }
+
+        .nav-link.active {
+            color: #fff;
+            border-color: rgba(76, 141, 255, 0.35);
+            background: linear-gradient(135deg, rgba(76, 141, 255, 0.32), rgba(17, 21, 34, 0.85));
+            box-shadow: 0 18px 36px rgba(76, 141, 255, 0.28);
+        }
+
+        h1 {
+            margin: 0;
+            font-size: 32px;
+            letter-spacing: 0.02em;
+        }
+
+        p {
+            color: var(--muted);
+            font-size: 15px;
+            margin: 12px 0 28px;
+            max-width: 720px;
+        }
+
+        .card {
+            background: var(--card);
+            border-radius: 22px;
+            border: 1px solid var(--border);
+            padding: 28px;
+            margin-bottom: 28px;
+            box-shadow: 0 48px 80px rgba(0, 0, 0, 0.35);
+        }
+
+        .card-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 16px;
+        }
+
+        .card-header h2 {
+            margin: 0;
+            font-size: 22px;
+        }
+
+        .tag {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 12px;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.06);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            color: var(--muted);
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+
+        .grid {
+            display: grid;
+            gap: 18px;
+        }
+
+        .grid.two {
+            grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        }
+
+        .override-card {
+            background: rgba(255, 255, 255, 0.03);
+            border-radius: 18px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            padding: 22px;
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+        }
+
+        .override-card header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .override-card header h3 {
+            margin: 0;
+            font-size: 20px;
+        }
+
+        .chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 10px;
+            border-radius: 999px;
+            background: rgba(76, 141, 255, 0.12);
+            color: var(--accent);
+            font-size: 12px;
+            border: 1px solid rgba(76, 141, 255, 0.32);
+        }
+
+        .chip.success {
+            background: rgba(61, 214, 140, 0.15);
+            border-color: rgba(61, 214, 140, 0.35);
+            color: var(--success);
+        }
+
+        .chip.warning {
+            background: rgba(255, 92, 141, 0.12);
+            border-color: rgba(255, 92, 141, 0.32);
+            color: var(--danger);
+        }
+
+        .settings-list {
+            display: grid;
+            gap: 8px;
+            font-size: 13px;
+            color: var(--muted);
+        }
+
+        .settings-list strong {
+            color: var(--text);
+            font-weight: 600;
+            margin-right: 6px;
+        }
+
+        .actions {
+            display: flex;
+            gap: 10px;
+        }
+
+        button {
+            border: none;
+            border-radius: 14px;
+            padding: 10px 16px;
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        button.primary {
+            background: linear-gradient(135deg, var(--accent), #6aa2ff);
+            color: #fff;
+            box-shadow: 0 14px 28px rgba(76, 141, 255, 0.35);
+        }
+
+        button.ghost {
+            background: rgba(255, 255, 255, 0.06);
+            color: var(--muted);
+            border: 1px solid rgba(255, 255, 255, 0.12);
+        }
+
+        button.danger {
+            background: rgba(255, 92, 141, 0.12);
+            color: var(--danger);
+            border: 1px solid rgba(255, 92, 141, 0.32);
+        }
+
+        button:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+        }
+
+        label {
+            display: block;
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--muted);
+            margin-bottom: 6px;
+        }
+
+        input[type="text"],
+        select {
+            width: 100%;
+            padding: 10px 12px;
+            border-radius: 12px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(10, 14, 24, 0.85);
+            color: var(--text);
+            font-size: 14px;
+        }
+
+        .toggle {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            background: rgba(255, 255, 255, 0.05);
+            border-radius: 14px;
+            padding: 14px 18px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+        }
+
+        .toggle span {
+            font-size: 13px;
+            color: var(--muted);
+        }
+
+        .switch {
+            position: relative;
+            width: 44px;
+            height: 24px;
+        }
+
+        .switch input {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+
+        .slider {
+            position: absolute;
+            cursor: pointer;
+            inset: 0;
+            background: rgba(255, 255, 255, 0.18);
+            border-radius: 999px;
+            transition: background 0.2s ease;
+        }
+
+        .slider::before {
+            content: "";
+            position: absolute;
+            height: 18px;
+            width: 18px;
+            left: 3px;
+            top: 3px;
+            border-radius: 50%;
+            background: #0b101b;
+            transition: transform 0.2s ease;
+        }
+
+        .switch input:checked + .slider {
+            background: linear-gradient(135deg, var(--accent), #6aa2ff);
+            box-shadow: 0 0 12px var(--accent-glow);
+        }
+
+        .switch input:checked + .slider::before {
+            transform: translateX(20px);
+            background: #fff;
+        }
+
+        .form-grid {
+            display: grid;
+            gap: 20px;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        }
+
+        .form-footer {
+            margin-top: 20px;
+            display: flex;
+            justify-content: flex-end;
+            gap: 12px;
+        }
+
+        .empty-state {
+            text-align: center;
+            color: var(--muted);
+            padding: 36px 20px;
+            border: 1px dashed rgba(255, 255, 255, 0.12);
+            border-radius: 16px;
+        }
+
+        .modal {
+            position: fixed;
+            inset: 0;
+            background: rgba(7, 10, 18, 0.72);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+            z-index: 999;
+        }
+
+        .modal.show {
+            display: flex;
+        }
+
+        .modal-card {
+            width: min(640px, 100%);
+            background: var(--card);
+            border-radius: 20px;
+            border: 1px solid rgba(76, 141, 255, 0.35);
+            padding: 26px;
+            box-shadow: 0 48px 80px rgba(0, 0, 0, 0.45);
+        }
+
+        .modal-card h3 {
+            margin: 0 0 18px;
+        }
+
+        .modal-footer {
+            margin-top: 22px;
+            display: flex;
+            justify-content: flex-end;
+            gap: 12px;
+        }
+
+        .toast {
+            position: fixed;
+            bottom: 24px;
+            right: 24px;
+            background: rgba(10, 14, 24, 0.92);
+            padding: 14px 18px;
+            border-radius: 12px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            color: var(--text);
+            font-size: 13px;
+            display: none;
+            box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+        }
+
+        .toast.show {
+            display: block;
+        }
+
+        @media (max-width: 960px) {
+            body {
+                padding: 26px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <nav class="nav-bar">
+        <a class="nav-link" href="log.html">Event Log</a>
+        <a class="nav-link" href="settings.html">Settings</a>
+        <a class="nav-link" href="site-info.html">Site Info</a>
+        <a class="nav-link active" href="site-overrides.html">Site Overrides</a>
+    </nav>
+    <header>
+        <h1>QA Assist — Site Overrides</h1>
+        <p>Create site-specific behaviours for playback, automation, and scanning. Overrides are applied whenever the current tab matches the configured domain.</p>
+    </header>
+
+    <section class="card">
+        <div class="card-header">
+            <h2>Configured Overrides</h2>
+            <span class="tag" id="overrideCount">0 overrides</span>
+        </div>
+        <div id="overrideContainer" class="grid two">
+            <div class="empty-state" id="overrideEmpty">No overrides created yet.</div>
+        </div>
+    </section>
+
+    <section class="card">
+        <div class="card-header">
+            <h2>Create Override</h2>
+            <span class="tag">New profile</span>
+        </div>
+        <div class="form-grid">
+            <div>
+                <label for="overrideName">Display Name</label>
+                <input type="text" id="overrideName" placeholder="e.g., Maules Creek Ops">
+            </div>
+            <div>
+                <label for="overridePattern">Domain / Pattern</label>
+                <input type="text" id="overridePattern" placeholder="e.g., 10.20.250.1">
+            </div>
+            <div>
+                <label for="overrideSpeed">Playback Speed</label>
+                <select id="overrideSpeed">
+                    <option value="1">1x</option>
+                    <option value="1.25">1.25x</option>
+                    <option value="1.5">1.5x</option>
+                    <option value="2">2x</option>
+                </select>
+            </div>
+            <div>
+                <label for="overrideKey">Key Mapping</label>
+                <select id="overrideKey">
+                    <option value="ArrowRight">OAS (➡)</option>
+                    <option value="ArrowDown">OpWeb (⬇)</option>
+                </select>
+            </div>
+        </div>
+        <div class="grid" style="margin-top: 18px;">
+            <div class="toggle">
+                <span>Enable scanning automatically</span>
+                <label class="switch">
+                    <input type="checkbox" id="overrideEnableScanning">
+                    <span class="slider"></span>
+                </label>
+            </div>
+            <div class="toggle">
+                <span>Override playback speed</span>
+                <label class="switch">
+                    <input type="checkbox" id="overrideSpeedToggle">
+                    <span class="slider"></span>
+                </label>
+            </div>
+            <div class="toggle">
+                <span>Override key mapping</span>
+                <label class="switch">
+                    <input type="checkbox" id="overrideKeyToggle">
+                    <span class="slider"></span>
+                </label>
+            </div>
+            <div class="toggle">
+                <span>Auto Press Next</span>
+                <label class="switch">
+                    <input type="checkbox" id="overrideAutoPress">
+                    <span class="slider"></span>
+                </label>
+            </div>
+            <div class="toggle">
+                <span>Remove Eye Tracker</span>
+                <label class="switch">
+                    <input type="checkbox" id="overrideEyeTracker">
+                    <span class="slider"></span>
+                </label>
+            </div>
+        </div>
+        <div class="form-footer">
+            <button class="ghost" id="clearOverrideForm">Clear</button>
+            <button class="primary" id="createOverride">Save Override</button>
+        </div>
+    </section>
+
+    <div class="modal" id="editModal">
+        <div class="modal-card">
+            <h3>Edit Override</h3>
+            <div class="form-grid">
+                <div>
+                    <label for="editName">Display Name</label>
+                    <input type="text" id="editName">
+                </div>
+                <div>
+                    <label for="editPattern">Domain / Pattern</label>
+                    <input type="text" id="editPattern">
+                </div>
+                <div>
+                    <label for="editSpeed">Playback Speed</label>
+                    <select id="editSpeed">
+                        <option value="1">1x</option>
+                        <option value="1.25">1.25x</option>
+                        <option value="1.5">1.5x</option>
+                        <option value="2">2x</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="editKey">Key Mapping</label>
+                    <select id="editKey">
+                        <option value="ArrowRight">OAS (➡)</option>
+                        <option value="ArrowDown">OpWeb (⬇)</option>
+                    </select>
+                </div>
+            </div>
+            <div class="grid" style="margin-top: 18px;">
+                <div class="toggle">
+                    <span>Enable scanning automatically</span>
+                    <label class="switch">
+                        <input type="checkbox" id="editEnableScanning">
+                        <span class="slider"></span>
+                    </label>
+                </div>
+                <div class="toggle">
+                    <span>Override playback speed</span>
+                    <label class="switch">
+                        <input type="checkbox" id="editSpeedToggle">
+                        <span class="slider"></span>
+                    </label>
+                </div>
+                <div class="toggle">
+                    <span>Override key mapping</span>
+                    <label class="switch">
+                        <input type="checkbox" id="editKeyToggle">
+                        <span class="slider"></span>
+                    </label>
+                </div>
+                <div class="toggle">
+                    <span>Auto Press Next</span>
+                    <label class="switch">
+                        <input type="checkbox" id="editAutoPress">
+                        <span class="slider"></span>
+                    </label>
+                </div>
+                <div class="toggle">
+                    <span>Remove Eye Tracker</span>
+                    <label class="switch">
+                        <input type="checkbox" id="editEyeTracker">
+                        <span class="slider"></span>
+                    </label>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button class="ghost" id="cancelEdit">Cancel</button>
+                <button class="primary" id="saveEdit">Save Changes</button>
+            </div>
+        </div>
+    </div>
+
+    <div class="toast" id="overrideToast"></div>
+
+    <script src="site-overrides.js"></script>
+</body>
+</html>

--- a/site-overrides.js
+++ b/site-overrides.js
@@ -1,0 +1,354 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const overrideContainer = document.getElementById("overrideContainer");
+    const overrideEmpty = document.getElementById("overrideEmpty");
+    const overrideCount = document.getElementById("overrideCount");
+
+    const nameInput = document.getElementById("overrideName");
+    const patternInput = document.getElementById("overridePattern");
+    const speedSelect = document.getElementById("overrideSpeed");
+    const keySelect = document.getElementById("overrideKey");
+    const enableScanningToggle = document.getElementById("overrideEnableScanning");
+    const speedToggle = document.getElementById("overrideSpeedToggle");
+    const keyToggle = document.getElementById("overrideKeyToggle");
+    const autoPressToggle = document.getElementById("overrideAutoPress");
+    const eyeTrackerToggle = document.getElementById("overrideEyeTracker");
+    const createButton = document.getElementById("createOverride");
+    const clearButton = document.getElementById("clearOverrideForm");
+
+    const editModal = document.getElementById("editModal");
+    const editNameInput = document.getElementById("editName");
+    const editPatternInput = document.getElementById("editPattern");
+    const editSpeedSelect = document.getElementById("editSpeed");
+    const editKeySelect = document.getElementById("editKey");
+    const editEnableScanningToggle = document.getElementById("editEnableScanning");
+    const editSpeedToggle = document.getElementById("editSpeedToggle");
+    const editKeyToggle = document.getElementById("editKeyToggle");
+    const editAutoPressToggle = document.getElementById("editAutoPress");
+    const editEyeTrackerToggle = document.getElementById("editEyeTracker");
+    const saveEditButton = document.getElementById("saveEdit");
+    const cancelEditButton = document.getElementById("cancelEdit");
+
+    const toast = document.getElementById("overrideToast");
+
+    let overrides = [];
+    let editingId = null;
+    let toastTimeout = null;
+
+    function generateId() {
+        if (typeof crypto !== "undefined" && crypto.randomUUID) {
+            return crypto.randomUUID();
+        }
+        return `override-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+    }
+
+    function normalizePattern(pattern) {
+        if (!pattern) {
+            return "";
+        }
+
+        let cleaned = pattern.trim().toLowerCase();
+        cleaned = cleaned.replace(/^https?:\/\//, "");
+        cleaned = cleaned.replace(/\/$/, "");
+        cleaned = cleaned.replace(/:.*/, "");
+        return cleaned;
+    }
+
+    function showToast(message) {
+        if (!toast) {
+            return;
+        }
+        toast.textContent = message;
+        toast.classList.add("show");
+
+        if (toastTimeout) {
+            clearTimeout(toastTimeout);
+        }
+
+        toastTimeout = setTimeout(() => {
+            toast.classList.remove("show");
+        }, 2200);
+    }
+
+    function broadcastOverrides() {
+        chrome.tabs.query({}, (tabs) => {
+            tabs.forEach((tab) => {
+                chrome.tabs.sendMessage(tab.id, { siteOverrides: overrides }, () => chrome.runtime.lastError);
+            });
+        });
+    }
+
+    function saveOverrides() {
+        chrome.storage.sync.set({ siteOverrides: overrides }, () => {
+            broadcastOverrides();
+        });
+    }
+
+    function clearForm() {
+        nameInput.value = "";
+        patternInput.value = "";
+        speedSelect.value = "1";
+        keySelect.value = "ArrowDown";
+        enableScanningToggle.checked = false;
+        speedToggle.checked = false;
+        keyToggle.checked = false;
+        autoPressToggle.checked = false;
+        eyeTrackerToggle.checked = false;
+        updateFormStates();
+    }
+
+    function updateFormStates() {
+        speedSelect.disabled = !speedToggle.checked;
+        speedSelect.style.opacity = speedToggle.checked ? "1" : "0.55";
+        keySelect.disabled = !keyToggle.checked;
+        keySelect.style.opacity = keyToggle.checked ? "1" : "0.55";
+
+        editSpeedSelect.disabled = !editSpeedToggle.checked;
+        editSpeedSelect.style.opacity = editSpeedToggle.checked ? "1" : "0.55";
+        editKeySelect.disabled = !editKeyToggle.checked;
+        editKeySelect.style.opacity = editKeyToggle.checked ? "1" : "0.55";
+    }
+
+    function renderOverrides() {
+        overrideContainer.innerHTML = "";
+        overrideCount.textContent = `${overrides.length} override${overrides.length === 1 ? "" : "s"}`;
+
+        if (!overrides.length) {
+            overrideContainer.appendChild(overrideEmpty);
+            overrideEmpty.style.display = "block";
+            return;
+        }
+
+        overrideEmpty.style.display = "none";
+
+        overrides
+            .slice()
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .forEach((override) => {
+                const card = document.createElement("div");
+                card.className = "override-card";
+
+                const header = document.createElement("header");
+                const title = document.createElement("h3");
+                title.textContent = override.name;
+
+                const statusChip = document.createElement("span");
+                statusChip.className = `chip ${override.enableScanning ? "success" : "warning"}`;
+                statusChip.textContent = override.enableScanning ? "Scanning On" : "Manual Activation";
+
+                header.appendChild(title);
+                header.appendChild(statusChip);
+
+                const settings = document.createElement("div");
+                settings.className = "settings-list";
+                settings.innerHTML = `
+                    <div><strong>Pattern:</strong>${override.pattern}</div>
+                    <div><strong>Playback:</strong>${override.overridePlaybackSpeed ? `${override.playbackSpeed}x` : "Inherit global"}</div>
+                    <div><strong>Key:</strong>${override.overridePressKey ? override.pressKey : "Inherit global"}</div>
+                    <div><strong>Auto Press Next:</strong>${override.autoPressNext ? "Enabled" : "Disabled"}</div>
+                    <div><strong>Eye Tracker:</strong>${override.removeEyeTracker ? "Removed" : "Leave default"}</div>
+                `;
+
+                const actions = document.createElement("div");
+                actions.className = "actions";
+
+                const editButton = document.createElement("button");
+                editButton.className = "ghost";
+                editButton.textContent = "Edit";
+                editButton.addEventListener("click", () => openEditModal(override.id));
+
+                const deleteButton = document.createElement("button");
+                deleteButton.className = "danger";
+                deleteButton.textContent = "Delete";
+                deleteButton.addEventListener("click", () => deleteOverride(override.id));
+
+                actions.appendChild(editButton);
+                actions.appendChild(deleteButton);
+
+                card.appendChild(header);
+                card.appendChild(settings);
+                card.appendChild(actions);
+
+                overrideContainer.appendChild(card);
+            });
+    }
+
+    function deleteOverride(id) {
+        const index = overrides.findIndex((override) => override.id === id);
+        if (index === -1) {
+            return;
+        }
+        if (!confirm("Delete this override?")) {
+            return;
+        }
+        overrides.splice(index, 1);
+        saveOverrides();
+        renderOverrides();
+        showToast("Override removed");
+    }
+
+    function collectFormData(inputs) {
+        const { nameField, patternField, speedField, keyField, enableField, speedOverrideField, keyOverrideField, autoPressField, eyeTrackerField } = inputs;
+
+        const name = nameField.value.trim();
+        const pattern = normalizePattern(patternField.value);
+
+        if (!name || !pattern) {
+            showToast("Provide both a name and pattern.");
+            return null;
+        }
+
+        const overridePlaybackSpeed = speedOverrideField.checked;
+        const overridePressKey = keyOverrideField.checked;
+
+        return {
+            name,
+            pattern,
+            overridePlaybackSpeed,
+            playbackSpeed: speedField.value,
+            overridePressKey,
+            pressKey: keyField.value,
+            enableScanning: enableField.checked,
+            autoPressNext: autoPressField.checked,
+            removeEyeTracker: eyeTrackerField.checked,
+        };
+    }
+
+    function createOverride() {
+        const data = collectFormData({
+            nameField: nameInput,
+            patternField: patternInput,
+            speedField: speedSelect,
+            keyField: keySelect,
+            enableField: enableScanningToggle,
+            speedOverrideField: speedToggle,
+            keyOverrideField: keyToggle,
+            autoPressField: autoPressToggle,
+            eyeTrackerField: eyeTrackerToggle,
+        });
+
+        if (!data) {
+            return;
+        }
+
+        const duplicate = overrides.some((override) => override.pattern === data.pattern);
+        if (duplicate) {
+            showToast("An override for this pattern already exists.");
+            return;
+        }
+
+        overrides.push({ id: generateId(), ...data });
+        saveOverrides();
+        renderOverrides();
+        clearForm();
+        showToast("Override added");
+    }
+
+    function openEditModal(id) {
+        const override = overrides.find((entry) => entry.id === id);
+        if (!override) {
+            return;
+        }
+
+        editingId = id;
+        editNameInput.value = override.name;
+        editPatternInput.value = override.pattern;
+        editSpeedSelect.value = override.playbackSpeed || "1";
+        editKeySelect.value = override.pressKey || "ArrowDown";
+        editEnableScanningToggle.checked = !!override.enableScanning;
+        editSpeedToggle.checked = !!override.overridePlaybackSpeed;
+        editKeyToggle.checked = !!override.overridePressKey;
+        editAutoPressToggle.checked = !!override.autoPressNext;
+        editEyeTrackerToggle.checked = !!override.removeEyeTracker;
+        updateFormStates();
+        editModal.classList.add("show");
+    }
+
+    function closeEditModal() {
+        editModal.classList.remove("show");
+        editingId = null;
+    }
+
+    function saveEdit() {
+        if (!editingId) {
+            closeEditModal();
+            return;
+        }
+
+        const override = overrides.find((entry) => entry.id === editingId);
+        if (!override) {
+            closeEditModal();
+            return;
+        }
+
+        const data = collectFormData({
+            nameField: editNameInput,
+            patternField: editPatternInput,
+            speedField: editSpeedSelect,
+            keyField: editKeySelect,
+            enableField: editEnableScanningToggle,
+            speedOverrideField: editSpeedToggle,
+            keyOverrideField: editKeyToggle,
+            autoPressField: editAutoPressToggle,
+            eyeTrackerField: editEyeTrackerToggle,
+        });
+
+        if (!data) {
+            return;
+        }
+
+        const duplicate = overrides.some((entry) => entry.id !== editingId && entry.pattern === data.pattern);
+        if (duplicate) {
+            showToast("Another override already uses this pattern.");
+            return;
+        }
+
+        Object.assign(override, data);
+        saveOverrides();
+        renderOverrides();
+        closeEditModal();
+        showToast("Override updated");
+    }
+
+
+    function attachToggleListeners() {
+        [speedToggle, editSpeedToggle].forEach((toggle) => {
+            toggle.addEventListener("change", updateFormStates);
+        });
+        [keyToggle, editKeyToggle].forEach((toggle) => {
+            toggle.addEventListener("change", updateFormStates);
+        });
+    }
+
+    patternInput.addEventListener("keydown", (event) => {
+        if (event.key === "Enter") {
+            event.preventDefault();
+            createOverride();
+        }
+    });
+
+    nameInput.addEventListener("keydown", (event) => {
+        if (event.key === "Enter") {
+            event.preventDefault();
+            createOverride();
+        }
+    });
+
+    createButton.addEventListener("click", createOverride);
+    clearButton.addEventListener("click", clearForm);
+    cancelEditButton.addEventListener("click", closeEditModal);
+    saveEditButton.addEventListener("click", saveEdit);
+
+    editModal.addEventListener("click", (event) => {
+        if (event.target === editModal) {
+            closeEditModal();
+        }
+    });
+
+    attachToggleListeners();
+    updateFormStates();
+
+    chrome.storage.sync.get("siteOverrides", (data) => {
+        overrides = Array.isArray(data.siteOverrides) ? data.siteOverrides : [];
+        renderOverrides();
+    });
+});


### PR DESCRIPTION
## Summary
- restore QA Assist branding with dynamic browser-action icons and add cross-page navigation with a dedicated settings screen
- capture validation types directly from the event DOM, normalize them for the allowed categories, and surface clearer context in the call modal
- update the Excel export row to split hour/minute columns while adding quick-copy helpers for event and call times

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d414c0170083238f8214208b009d1e