### PR TITLE
Enhance navigation and call validation workflow

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,3 +7,29 @@ chrome.tabs.onActivated.addListener(() => {
         });
     });
 });
+
+function updateBrowserActionIcon(isEnabled) {
+    if (chrome.browserAction) {
+        chrome.browserAction.setIcon({ path: isEnabled ? "on.png" : "off.png" });
+    }
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+    chrome.storage.sync.get("enabled", function (data) {
+        const enabled = typeof data.enabled === "boolean" ? data.enabled : false;
+        updateBrowserActionIcon(enabled);
+    });
+});
+
+chrome.runtime.onStartup.addListener(() => {
+    chrome.storage.sync.get("enabled", function (data) {
+        const enabled = typeof data.enabled === "boolean" ? data.enabled : false;
+        updateBrowserActionIcon(enabled);
+    });
+});
+
+chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === "sync" && changes.enabled) {
+        updateBrowserActionIcon(changes.enabled.newValue);
+    }
+});

--- a/call-validation.html
+++ b/call-validation.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>QA Assist - Call Validation</title>
+    <link rel="stylesheet" href="styles/common.css">
+    <style>
+        .form-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 16px;
+        }
+
+        .button-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            margin-top: 20px;
+        }
+
+        .button-row button {
+            flex: 1 1 160px;
+        }
+
+        .confirm-overlay {
+            position: fixed;
+            inset: 0;
+            background-color: rgba(0, 0, 0, 0.7);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 1000;
+        }
+
+        .confirm-card {
+            background-color: #2c3244;
+            border: 1px solid #3f465d;
+            border-radius: 8px;
+            padding: 24px;
+            max-width: 360px;
+            text-align: center;
+            box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+        }
+
+        .confirm-buttons {
+            display: flex;
+            gap: 12px;
+            margin-top: 20px;
+            justify-content: center;
+        }
+
+        .hidden {
+            display: none !important;
+        }
+
+        .table-empty {
+            text-align: center;
+            padding: 18px;
+            color: #9aa0bb;
+        }
+    </style>
+</head>
+<body>
+    <nav class="top-nav">
+        <button data-nav-target="call-validation.html">Call Validation</button>
+        <button data-nav-target="settings.html">Settings</button>
+        <button data-nav-target="log.html">Event Log</button>
+        <button data-nav-target="site-info.html">Site Info</button>
+    </nav>
+    <main>
+        <section class="section-card">
+            <h2>Call Validation Entry</h2>
+            <div class="form-grid">
+                <div>
+                    <label for="callDate">Event Date</label>
+                    <input type="date" id="callDate">
+                </div>
+                <div>
+                    <label for="eventTime">Event Time (HH:MM:SS)</label>
+                    <input type="text" id="eventTime" placeholder="01:26:16">
+                </div>
+                <div>
+                    <label for="firstCallTime">1st Call Time (HH:MM)</label>
+                    <input type="text" id="firstCallTime" placeholder="01:30">
+                </div>
+                <div>
+                    <label for="secondCallTime">2nd Call Time (HH:MM)</label>
+                    <input type="text" id="secondCallTime" placeholder="01:45">
+                </div>
+                <div>
+                    <label for="thirdCallTime">3rd Call Time (HH:MM)</label>
+                    <input type="text" id="thirdCallTime" placeholder="02:10">
+                </div>
+                <div>
+                    <label for="siteName">Site Name</label>
+                    <input type="text" id="siteName" placeholder="Site name">
+                </div>
+                <div>
+                    <label for="equipmentNumber">Equipment Number</label>
+                    <input type="text" id="equipmentNumber" placeholder="Unit / Truck number">
+                </div>
+                <div>
+                    <label for="validationType">Validation Type</label>
+                    <select id="validationType">
+                        <option value="">Select validation...</option>
+                        <option value="Blocked">Blocked</option>
+                        <option value="Critical">Critical</option>
+                        <option value="Moderate">Moderate</option>
+                        <option value="3 Low/hr">3 Low/hr</option>
+                        <option value="Cellphone">Cellphone</option>
+                        <option value="False Positive">False Positive</option>
+                        <option value="Lost Connection">Lost Connection</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="monitorName">Monitor Name</label>
+                    <input type="text" id="monitorName" placeholder="Your name">
+                </div>
+                <div>
+                    <label for="contact">Contact</label>
+                    <input type="text" id="contact" placeholder="Phone / Radio">
+                </div>
+                <div>
+                    <label for="receptor">Receptor</label>
+                    <input type="text" id="receptor" placeholder="Who answered">
+                </div>
+            </div>
+            <div class="button-row">
+                <button class="secondary" id="loadLatest">Load Latest Event</button>
+                <button class="secondary" id="clearForm">Clear Form</button>
+                <button class="primary" id="saveCall">Save Call</button>
+            </div>
+            <div class="status-message" id="formStatus"></div>
+        </section>
+
+        <section class="section-card">
+            <div class="section-header" style="justify-content: space-between; align-items: center;">
+                <h2>Saved Call Validations</h2>
+                <button class="secondary" id="copyAll">Copy Latest Row</button>
+            </div>
+            <div class="table-container">
+                <table id="callValidationTable">
+                    <thead>
+                        <tr>
+                            <th>Date</th>
+                            <th>Event Time HR</th>
+                            <th>Event Time MIN</th>
+                            <th>1st Call HR</th>
+                            <th>1st Call MIN</th>
+                            <th>2nd Call HR</th>
+                            <th>2nd Call MIN</th>
+                            <th>3rd Call HR</th>
+                            <th>3rd Call MIN</th>
+                            <th>Site Name</th>
+                            <th>Equipment Number</th>
+                            <th>Validation Type</th>
+                            <th>Monitor Name</th>
+                            <th>Contact</th>
+                            <th>Receptor</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="callValidationBody"></tbody>
+                </table>
+            </div>
+        </section>
+    </main>
+
+    <div id="validationConfirm" class="confirm-overlay hidden">
+        <div class="confirm-card">
+            <p id="confirmText">Is this the correct validation type?</p>
+            <div class="confirm-buttons">
+                <button id="confirmYes" class="primary">Yes</button>
+                <button id="confirmNo" class="secondary">No</button>
+            </div>
+        </div>
+    </div>
+
+    <script src="navigation.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            initNavigation('call-validation.html');
+        });
+    </script>
+    <script src="call-validation.js"></script>
+</body>
+</html>

--- a/call-validation.js
+++ b/call-validation.js
@@ -1,0 +1,457 @@
+(function () {
+    const VALIDATION_OPTIONS = [
+        "",
+        "Blocked",
+        "Critical",
+        "Moderate",
+        "3 Low/hr",
+        "Cellphone",
+        "False Positive",
+        "Lost Connection",
+    ];
+
+    document.addEventListener('DOMContentLoaded', function () {
+        const form = {
+            callDate: document.getElementById('callDate'),
+            eventTime: document.getElementById('eventTime'),
+            firstCallTime: document.getElementById('firstCallTime'),
+            secondCallTime: document.getElementById('secondCallTime'),
+            thirdCallTime: document.getElementById('thirdCallTime'),
+            siteName: document.getElementById('siteName'),
+            equipmentNumber: document.getElementById('equipmentNumber'),
+            validationType: document.getElementById('validationType'),
+            monitorName: document.getElementById('monitorName'),
+            contact: document.getElementById('contact'),
+            receptor: document.getElementById('receptor'),
+        };
+
+        const statusMessage = document.getElementById('formStatus');
+        const tableBody = document.getElementById('callValidationBody');
+        const copyLatestButton = document.getElementById('copyAll');
+        const confirmOverlay = document.getElementById('validationConfirm');
+        const confirmText = document.getElementById('confirmText');
+        const confirmYes = document.getElementById('confirmYes');
+        const confirmNo = document.getElementById('confirmNo');
+
+        let callEntries = [];
+        let latestEventDetails = null;
+        let pendingEntry = null;
+        let defaults = {};
+
+        function normalizeExistingEntries(entries) {
+            return entries.map(function (entry) {
+                const normalized = Object.assign({}, entry);
+                normalized.dateIso = entry.dateIso || entry.dateISO || '';
+                if (!normalized.dateDisplay) {
+                    normalized.dateDisplay = entry.dateDisplay || formatDateDisplay(normalized.dateIso);
+                }
+                if (!normalized.eventTime || typeof normalized.eventTime !== 'object') {
+                    normalized.eventTime = splitTime(entry.eventTimeRaw || entry.eventTime || '');
+                }
+                if (!normalized.firstCall || typeof normalized.firstCall !== 'object') {
+                    normalized.firstCall = splitTime(entry.firstCallRaw || '');
+                }
+                if (!normalized.secondCall || typeof normalized.secondCall !== 'object') {
+                    normalized.secondCall = splitTime(entry.secondCallRaw || '');
+                }
+                if (!normalized.thirdCall || typeof normalized.thirdCall !== 'object') {
+                    normalized.thirdCall = splitTime(entry.thirdCallRaw || '');
+                }
+                normalized.siteName = normalized.siteName || entry.site || '';
+                normalized.equipmentNumber = normalized.equipmentNumber || entry.equipment || entry.truckNumber || '';
+                normalized.validationType = normalized.validationType || entry.validation || '';
+                normalized.monitorName = normalized.monitorName || '';
+                normalized.contact = normalized.contact || '';
+                normalized.receptor = normalized.receptor || '';
+                normalized.id = normalized.id || Date.now() + Math.floor(Math.random() * 1000);
+                return normalized;
+            });
+        }
+
+        function setStatus(message, isError) {
+            if (!statusMessage) {
+                return;
+            }
+            statusMessage.textContent = message || '';
+            statusMessage.style.color = isError ? '#ff9090' : '#8fd18b';
+        }
+
+        function splitTime(value) {
+            if (!value) {
+                return { hr: '', min: '' };
+            }
+            const trimmed = value.trim();
+            if (!trimmed) {
+                return { hr: '', min: '' };
+            }
+            const parts = trimmed.split(':');
+            const hrPart = parts[0];
+            const minPart = parts.length > 1 ? parts[1] : '';
+
+            const hr = hrPart === undefined || hrPart === '' ? '' : String(parseInt(hrPart, 10) || 0);
+            const min = minPart === undefined || minPart === '' ? '' : String(parseInt(minPart, 10) || 0);
+
+            return { hr, min };
+        }
+
+        function formatDateDisplay(iso) {
+            if (!iso) {
+                return '';
+            }
+            const parts = iso.split('-');
+            if (parts.length !== 3) {
+                return iso;
+            }
+            const year = parseInt(parts[0], 10);
+            const month = parseInt(parts[1], 10);
+            const day = parseInt(parts[2], 10);
+            if (isNaN(year) || isNaN(month) || isNaN(day)) {
+                return iso;
+            }
+            return month + '/' + day + '/' + year;
+        }
+
+        function copyToClipboard(text, successMessage) {
+            if (!text) {
+                setStatus('Nothing to copy.', true);
+                return;
+            }
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(text).then(function () {
+                    setStatus(successMessage || 'Copied to clipboard.');
+                }).catch(function () {
+                    fallbackCopy(text, successMessage);
+                });
+            } else {
+                fallbackCopy(text, successMessage);
+            }
+        }
+
+        function fallbackCopy(text, successMessage) {
+            const textarea = document.createElement('textarea');
+            textarea.value = text;
+            textarea.setAttribute('readonly', '');
+            textarea.style.position = 'absolute';
+            textarea.style.left = '-9999px';
+            document.body.appendChild(textarea);
+            textarea.select();
+            try {
+                document.execCommand('copy');
+                setStatus(successMessage || 'Copied to clipboard.');
+            } catch (err) {
+                setStatus('Unable to copy to clipboard.', true);
+            }
+            document.body.removeChild(textarea);
+        }
+
+        function rowToClipboard(entry) {
+            const parts = [
+                entry.dateDisplay || '',
+                entry.eventTime.hr,
+                entry.eventTime.min,
+                entry.firstCall.hr,
+                entry.firstCall.min,
+                entry.secondCall.hr,
+                entry.secondCall.min,
+                entry.thirdCall.hr,
+                entry.thirdCall.min,
+                entry.siteName,
+                entry.equipmentNumber,
+                entry.validationType,
+                entry.monitorName,
+                entry.contact,
+                entry.receptor,
+            ];
+            return parts.join('\t');
+        }
+
+        function callTimesToClipboard(entry) {
+            const parts = [
+                entry.firstCall.hr,
+                entry.firstCall.min,
+                entry.secondCall.hr,
+                entry.secondCall.min,
+                entry.thirdCall.hr,
+                entry.thirdCall.min,
+            ];
+            return parts.join('\t');
+        }
+
+        function eventTimeToClipboard(entry) {
+            return [entry.eventTime.hr, entry.eventTime.min].join('\t');
+        }
+
+        function storeEntries() {
+            chrome.storage.local.set({ callValidations: callEntries });
+        }
+
+        function storeDefaults(entry) {
+            defaults = {
+                monitorName: entry.monitorName || defaults.monitorName || '',
+                contact: entry.contact || defaults.contact || '',
+                receptor: entry.receptor || defaults.receptor || '',
+            };
+            chrome.storage.sync.set({ callValidationDefaults: defaults });
+        }
+
+        function renderTable() {
+            tableBody.innerHTML = '';
+            if (!callEntries.length) {
+                const emptyRow = document.createElement('tr');
+                const cell = document.createElement('td');
+                cell.colSpan = 16;
+                cell.className = 'table-empty';
+                cell.textContent = 'No saved calls yet.';
+                emptyRow.appendChild(cell);
+                tableBody.appendChild(emptyRow);
+                return;
+            }
+
+            callEntries.forEach(function (entry) {
+                const row = document.createElement('tr');
+                row.innerHTML = `
+                    <td>${entry.dateDisplay || ''}</td>
+                    <td>${entry.eventTime.hr || ''}</td>
+                    <td>${entry.eventTime.min || ''}</td>
+                    <td>${entry.firstCall.hr || ''}</td>
+                    <td>${entry.firstCall.min || ''}</td>
+                    <td>${entry.secondCall.hr || ''}</td>
+                    <td>${entry.secondCall.min || ''}</td>
+                    <td>${entry.thirdCall.hr || ''}</td>
+                    <td>${entry.thirdCall.min || ''}</td>
+                    <td>${entry.siteName || ''}</td>
+                    <td>${entry.equipmentNumber || ''}</td>
+                    <td>${entry.validationType || ''}</td>
+                    <td>${entry.monitorName || ''}</td>
+                    <td>${entry.contact || ''}</td>
+                    <td>${entry.receptor || ''}</td>
+                    <td class="actions-cell"></td>
+                `;
+
+                const actionsCell = row.querySelector('.actions-cell');
+
+                const copyRowBtn = document.createElement('button');
+                copyRowBtn.className = 'secondary';
+                copyRowBtn.textContent = 'Copy Row';
+                copyRowBtn.addEventListener('click', function () {
+                    copyToClipboard(rowToClipboard(entry), 'Call validation row copied.');
+                });
+
+                const copyEventBtn = document.createElement('button');
+                copyEventBtn.className = 'secondary';
+                copyEventBtn.textContent = 'Only Copy Event Time';
+                copyEventBtn.addEventListener('click', function () {
+                    copyToClipboard(eventTimeToClipboard(entry), 'Event time copied.');
+                });
+
+                const copyCallBtn = document.createElement('button');
+                copyCallBtn.className = 'secondary';
+                copyCallBtn.textContent = 'Only Copy Call Time';
+                copyCallBtn.addEventListener('click', function () {
+                    copyToClipboard(callTimesToClipboard(entry), 'Call times copied.');
+                });
+
+                const deleteBtn = document.createElement('button');
+                deleteBtn.className = 'secondary';
+                deleteBtn.textContent = 'Delete';
+                deleteBtn.addEventListener('click', function () {
+                    callEntries = callEntries.filter(function (item) {
+                        return item.id !== entry.id;
+                    });
+                    storeEntries();
+                    renderTable();
+                    setStatus('Entry deleted.');
+                });
+
+                actionsCell.appendChild(copyRowBtn);
+                actionsCell.appendChild(copyEventBtn);
+                actionsCell.appendChild(copyCallBtn);
+                actionsCell.appendChild(deleteBtn);
+
+                tableBody.appendChild(row);
+            });
+        }
+
+        function buildEntryFromForm() {
+            const dateIso = form.callDate.value;
+            const validationValue = form.validationType.value;
+
+            if (!validationValue) {
+                setStatus('Please select a validation type before saving.', true);
+                form.validationType.focus();
+                return null;
+            }
+
+            const entry = {
+                id: Date.now(),
+                dateIso: dateIso || '',
+                dateDisplay: formatDateDisplay(dateIso),
+                eventTime: splitTime(form.eventTime.value),
+                firstCall: splitTime(form.firstCallTime.value),
+                secondCall: splitTime(form.secondCallTime.value),
+                thirdCall: splitTime(form.thirdCallTime.value),
+                siteName: form.siteName.value.trim(),
+                equipmentNumber: form.equipmentNumber.value.trim(),
+                validationType: validationValue,
+                monitorName: form.monitorName.value.trim(),
+                contact: form.contact.value.trim(),
+                receptor: form.receptor.value.trim(),
+            };
+
+            return entry;
+        }
+
+        function openConfirm(entry) {
+            pendingEntry = entry;
+            confirmText.textContent = 'Is "' + entry.validationType + '" the correct validation type?';
+            confirmOverlay.classList.remove('hidden');
+        }
+
+        function closeConfirm() {
+            confirmOverlay.classList.add('hidden');
+            pendingEntry = null;
+        }
+
+        function finalizeSave(entry) {
+            callEntries.push(entry);
+            storeEntries();
+            storeDefaults(entry);
+            renderTable();
+            setStatus('Call validation saved.');
+        }
+
+        function clearForm(preserveDefaults) {
+            form.callDate.value = '';
+            form.eventTime.value = '';
+            form.firstCallTime.value = '';
+            form.secondCallTime.value = '';
+            form.thirdCallTime.value = '';
+            form.siteName.value = '';
+            form.equipmentNumber.value = '';
+            form.validationType.value = '';
+            if (!preserveDefaults) {
+                form.monitorName.value = defaults.monitorName || '';
+                form.contact.value = defaults.contact || '';
+                form.receptor.value = defaults.receptor || '';
+            }
+        }
+
+        function fillDefaults() {
+            if (defaults.monitorName && !form.monitorName.value) {
+                form.monitorName.value = defaults.monitorName;
+            }
+            if (defaults.contact && !form.contact.value) {
+                form.contact.value = defaults.contact;
+            }
+            if (defaults.receptor && !form.receptor.value) {
+                form.receptor.value = defaults.receptor;
+            }
+        }
+
+        function applyLatestEvent(details) {
+            if (!details) {
+                return;
+            }
+            latestEventDetails = details;
+            if (details.dateISO) {
+                form.callDate.value = details.dateISO;
+            } else if (details.dateDisplay) {
+                const parts = details.dateDisplay.split('/');
+                if (parts.length === 3) {
+                    const month = parts[0].padStart(2, '0');
+                    const day = parts[1].padStart(2, '0');
+                    form.callDate.value = parts[2] + '-' + month + '-' + day;
+                }
+            }
+            if (details.timeRaw) {
+                form.eventTime.value = details.timeRaw;
+            } else if (details.eventTimeHr || details.eventTimeMin) {
+                let hr = '';
+                if (details.eventTimeHr !== undefined && details.eventTimeHr !== null && details.eventTimeHr !== '') {
+                    const hrNumber = parseInt(details.eventTimeHr, 10);
+                    hr = isNaN(hrNumber) ? String(details.eventTimeHr) : String(hrNumber);
+                }
+                let min = '';
+                if (details.eventTimeMin !== undefined && details.eventTimeMin !== null && details.eventTimeMin !== '') {
+                    const minNumber = parseInt(details.eventTimeMin, 10);
+                    min = isNaN(minNumber) ? String(details.eventTimeMin) : String(minNumber).padStart(2, '0');
+                }
+                if (hr !== '' || min !== '') {
+                    const paddedHr = hr !== '' ? (isNaN(parseInt(hr, 10)) ? hr : String(parseInt(hr, 10))) : '';
+                    const paddedMin = min !== '' ? min : '00';
+                    const displayHr = paddedHr !== '' ? paddedHr : '0';
+                    form.eventTime.value = displayHr + ':' + paddedMin;
+                }
+            }
+            if (details.siteName) {
+                form.siteName.value = details.siteName;
+            }
+            if (details.equipmentNumber) {
+                form.equipmentNumber.value = details.equipmentNumber;
+            } else if (details.truckNumber) {
+                form.equipmentNumber.value = details.truckNumber;
+            }
+            if (details.validationType && VALIDATION_OPTIONS.indexOf(details.validationType) !== -1) {
+                form.validationType.value = details.validationType;
+            } else {
+                form.validationType.value = '';
+            }
+            fillDefaults();
+        }
+
+        document.getElementById('saveCall').addEventListener('click', function () {
+            const entry = buildEntryFromForm();
+            if (!entry) {
+                return;
+            }
+            openConfirm(entry);
+        });
+
+        confirmYes.addEventListener('click', function () {
+            if (pendingEntry) {
+                finalizeSave(pendingEntry);
+                closeConfirm();
+            }
+        });
+
+        confirmNo.addEventListener('click', function () {
+            closeConfirm();
+            form.validationType.focus();
+        });
+
+        document.getElementById('clearForm').addEventListener('click', function () {
+            clearForm(false);
+            setStatus('Form cleared.');
+        });
+
+        document.getElementById('loadLatest').addEventListener('click', function () {
+            if (!latestEventDetails) {
+                setStatus('No recent event details available. Try watching an event.', true);
+                return;
+            }
+            applyLatestEvent(latestEventDetails);
+            setStatus('Latest event details loaded.');
+        });
+
+        copyLatestButton.addEventListener('click', function () {
+            if (!callEntries.length) {
+                setStatus('No rows available to copy.', true);
+                return;
+            }
+            const latest = callEntries[callEntries.length - 1];
+            copyToClipboard(rowToClipboard(latest), 'Latest row copied.');
+        });
+
+        chrome.storage.local.get(['callValidations', 'latestEventDetails'], function (data) {
+            callEntries = Array.isArray(data.callValidations) ? normalizeExistingEntries(data.callValidations) : [];
+            latestEventDetails = data.latestEventDetails || null;
+            renderTable();
+            applyLatestEvent(latestEventDetails);
+        });
+
+        chrome.storage.sync.get(['callValidationDefaults'], function (data) {
+            defaults = data.callValidationDefaults || {};
+            fillDefaults();
+        });
+    });
+})();

--- a/content.js
+++ b/content.js
@@ -4,6 +4,242 @@ let pressKey = "ArrowRight"; // Default key
 let autoPressNext = false; // Default to disabled
 let removeEyeTracker = false; // Default to disabled
 
+function normalizeValidationType(rawValue) {
+    if (!rawValue) {
+        return "";
+    }
+    const value = rawValue.toLowerCase();
+
+    if (value.indexOf("blocked") !== -1) {
+        return "Blocked";
+    }
+    if (value.indexOf("critical") !== -1) {
+        return "Critical";
+    }
+    if (value.indexOf("moderate") !== -1) {
+        return "Moderate";
+    }
+    if (value.indexOf("low") !== -1) {
+        return "3 Low/hr";
+    }
+    if (value.indexOf("cell") !== -1) {
+        return "Cellphone";
+    }
+    if (value.indexOf("non") !== -1 || value.indexOf("false") !== -1) {
+        return "False Positive";
+    }
+    if (value.indexOf("lost") !== -1 && value.indexOf("connection") !== -1) {
+        return "Lost Connection";
+    }
+    if (value.indexOf("disconnect") !== -1) {
+        return "Lost Connection";
+    }
+
+    return "";
+}
+
+function parseTimestampParts(timestamp) {
+    if (!timestamp) {
+        return {
+            dateISO: "",
+            dateDisplay: "",
+            hour: "",
+            minute: "",
+            seconds: "",
+            timeRaw: "",
+        };
+    }
+
+    const timeMatch = timestamp.match(/(\d{1,2}):(\d{2})(?::(\d{2}))?/);
+    let hour = "";
+    let minute = "";
+    let seconds = "";
+    let timeRaw = "";
+    if (timeMatch) {
+        hour = String(parseInt(timeMatch[1], 10) || 0);
+        minute = String(parseInt(timeMatch[2], 10) || 0);
+        seconds = typeof timeMatch[3] !== "undefined" ? String(parseInt(timeMatch[3], 10) || 0) : "";
+        timeRaw = timeMatch[0];
+    }
+
+    const dateMatch = timestamp.match(/(\d{4}-\d{2}-\d{2})|(\d{1,2}[\/\-]\d{1,2}[\/\-]\d{2,4})/);
+    let dateISO = "";
+    let dateDisplay = "";
+    if (dateMatch) {
+        const rawDate = dateMatch[0];
+        let year;
+        let month;
+        let day;
+
+        if (rawDate.indexOf("-") !== -1 && rawDate.length >= 8) {
+            const parts = rawDate.split("-");
+            if (parts[0].length === 4) {
+                year = parseInt(parts[0], 10);
+                month = parseInt(parts[1], 10);
+                day = parseInt(parts[2], 10);
+            } else {
+                month = parseInt(parts[0], 10);
+                day = parseInt(parts[1], 10);
+                year = parseInt(parts[2], 10);
+            }
+        } else {
+            const parts = rawDate.split(/[\/\-]/);
+            month = parseInt(parts[0], 10);
+            day = parseInt(parts[1], 10);
+            const rawYear = parts[2];
+            year = rawYear.length === 2 ? 2000 + parseInt(rawYear, 10) : parseInt(rawYear, 10);
+        }
+
+        if (!isNaN(year) && !isNaN(month) && !isNaN(day)) {
+            const monthStr = month < 10 ? "0" + month : String(month);
+            const dayStr = day < 10 ? "0" + day : String(day);
+            dateISO = year + "-" + monthStr + "-" + dayStr;
+            dateDisplay = month + "/" + day + "/" + year;
+        }
+    }
+
+    return {
+        dateISO,
+        dateDisplay,
+        hour,
+        minute,
+        seconds,
+        timeRaw,
+    };
+}
+
+function findValueByLabel(container, regex) {
+    if (!container) {
+        return "";
+    }
+
+    const elements = container.querySelectorAll("label, span, div, dt, dd, th, td, strong, p");
+    for (let i = 0; i < elements.length; i += 1) {
+        const element = elements[i];
+        const text = (element.textContent || "").trim();
+        if (!text) {
+            continue;
+        }
+
+        if (regex.test(text)) {
+            const directParts = text.split(/[:：]/);
+            if (directParts.length > 1) {
+                const candidate = directParts.slice(1).join(":").trim();
+                if (candidate && !regex.test(candidate)) {
+                    return candidate;
+                }
+            }
+
+            const next = element.nextElementSibling;
+            if (next) {
+                const nextText = (next.textContent || "").trim();
+                if (nextText && !regex.test(nextText)) {
+                    return nextText;
+                }
+            }
+
+            const parent = element.parentElement;
+            if (parent) {
+                const siblings = parent.children;
+                for (let j = 0; j < siblings.length; j += 1) {
+                    const sibling = siblings[j];
+                    if (sibling === element) {
+                        continue;
+                    }
+                    const siblingText = (sibling.textContent || "").trim();
+                    if (siblingText && !regex.test(siblingText)) {
+                        return siblingText;
+                    }
+                }
+            }
+        }
+    }
+
+    return "";
+}
+
+function extractValidationTypeFromContainer(container, eventType) {
+    if (!container) {
+        return "";
+    }
+
+    const selectors = [
+        "[data-field='validation_type']",
+        "[data-field='validationType']",
+        ".field-validation_type",
+        ".validation-type",
+        "[data-label='Validation Type']",
+        "[aria-label='Validation Type']",
+    ];
+
+    for (let i = 0; i < selectors.length; i += 1) {
+        const element = container.querySelector(selectors[i]);
+        if (element) {
+            const text = (element.textContent || "").trim();
+            if (text) {
+                return text;
+            }
+        }
+    }
+
+    const dataAttribute = container.getAttribute && container.getAttribute("data-validation-type");
+    if (dataAttribute) {
+        return dataAttribute.trim();
+    }
+
+    const labelledValue = findValueByLabel(container, /validation\s*type/i);
+    if (labelledValue) {
+        return labelledValue;
+    }
+
+    if (container !== document.body && container !== document) {
+        const parentLabelledValue = findValueByLabel(document.body, /validation\s*type/i);
+        if (parentLabelledValue) {
+            return parentLabelledValue;
+        }
+    }
+
+    if (eventType) {
+        return eventType;
+    }
+
+    return "";
+}
+
+function deriveSiteName() {
+    const explicit = findValueByLabel(document.body, /site\s*name/i);
+    if (explicit) {
+        return explicit;
+    }
+
+    if (typeof window !== "undefined" && window.location && window.location.hostname) {
+        return window.location.hostname;
+    }
+
+    return "";
+}
+
+function storeLatestEventDetails(eventData, validationDetails, timestampParts) {
+    const latestEventDetails = {
+        eventType: eventData.eventType,
+        timestamp: eventData.timestamp,
+        pageUrl: eventData.pageUrl,
+        truckNumber: eventData.truckNumber,
+        equipmentNumber: eventData.truckNumber,
+        siteName: deriveSiteName(),
+        validationTypeRaw: validationDetails.raw,
+        validationType: validationDetails.normalized,
+        dateISO: timestampParts.dateISO,
+        dateDisplay: timestampParts.dateDisplay,
+        eventTimeHr: timestampParts.hour,
+        eventTimeMin: timestampParts.minute,
+        seconds: timestampParts.seconds,
+        timeRaw: timestampParts.timeRaw,
+    };
+
+    chrome.storage.local.set({ latestEventDetails });
+}
+
 // Function to store event data from the selected row
 function saveEventData(video) {
     let allRows = document.querySelectorAll(".gvEventListItemPadding");
@@ -15,6 +251,7 @@ function saveEventData(video) {
     let timestamp = "";
     let pageUrl = window.location.href;
     let isLastCell = false;
+    let containerForValidation = null;
 
     if (isHideTracking) {
         // Get the selected container within hide-tracking
@@ -31,6 +268,7 @@ function saveEventData(video) {
                 timestamp = timestampElement.textContent.trim();
             }
 
+            containerForValidation = selectedItem;
             console.log("📌 Logging event from hide-tracking video (selected item):", { eventType, timestamp, pageUrl });
         } else {
             console.warn("⚠️ No selected item found for hide-tracking video.");
@@ -55,13 +293,26 @@ function saveEventData(video) {
             timestamp = timestampElement.textContent.trim();
         }
 
+        containerForValidation = selectedRow;
         console.log("📌 Logging event from normal video:", { eventType, truckNumber, timestamp, pageUrl, isLastCell });
     } else {
         console.warn("⚠️ No selected row found for event logging.");
         return false;
     }
 
-    let eventData = { eventType, truckNumber, timestamp, pageUrl, isLastCell };
+    const rawValidation = extractValidationTypeFromContainer(containerForValidation || document.body, eventType);
+    const normalizedValidation = normalizeValidationType(rawValidation);
+    const timestampParts = parseTimestampParts(timestamp);
+
+    let eventData = {
+        eventType,
+        truckNumber,
+        timestamp,
+        pageUrl,
+        isLastCell,
+        validationTypeRaw: rawValidation,
+        validationType: normalizedValidation,
+    };
 
     chrome.storage.local.get("eventLogs", function (data) {
         let logs = data.eventLogs || [];
@@ -70,6 +321,8 @@ function saveEventData(video) {
         chrome.storage.local.set({ eventLogs: logs });
         console.log("📌 Event logged successfully:", eventData);
     });
+
+    storeLatestEventDetails(eventData, { raw: rawValidation, normalized: normalizedValidation }, timestampParts);
 
     return isLastCell;
 }

--- a/log.html
+++ b/log.html
@@ -1,25 +1,15 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta charset="UFC-8">
-    <title>Event Log</title>
+    <meta charset="UTF-8">
+    <title>QA Assist - Event Log</title>
+    <link rel="stylesheet" href="styles/common.css">
     <style>
-        body {
-            font-family: Arial, sans-serif;
-            background-color: #222;
-            color: #fff;
-            padding: 20px;
-        }
-
-        h2 {
-            margin: 0;
-        }
-
         .section-header {
             display: flex;
             justify-content: space-between;
             align-items: center;
-            padding: 10px 0;
+            gap: 12px;
         }
 
         .button-group {
@@ -27,138 +17,106 @@
             gap: 10px;
         }
 
-        #clearLogs,
-        #exportCSV {
-            background-color: #cc0000;
-            color: white;
-            border: none;
-            border-radius: 5px;
-            cursor: pointer;
-            font-size: 14px;
-            padding: 8px 12px;
+        .button-group .danger {
+            border-color: #ff5c5c;
+            color: #ff8a8a;
         }
 
-        #exportCSV {
-            background-color: #007bff;
+        .button-group .danger:hover {
+            background-color: rgba(255, 92, 92, 0.1);
         }
 
-        #clearLogs:hover {
-            background-color: #ff4444;
-        }
-
-        #exportCSV:hover {
-            background-color: #3399ff;
-        }
-
-        #filterInput {
-            width: 100%;
-            padding: 8px;
-            margin: 10px 0;
-            border: 1px solid #555;
-            border-radius: 5px;
-            background-color: #333;
-            color: white;
-        }
-
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            margin-top: 10px;
-        }
-
-        th,
-        td {
-            padding: 10px;
-            border: 1px solid #555;
-            text-align: left;
-        }
-
-        th {
-            background-color: #444;
-        }
-
-        tr:nth-child(even) {
-            background-color: #333;
-        }
-
-        tr:hover {
-            background-color: #555;
+        .filter-input {
+            margin-top: 12px;
+            margin-bottom: 12px;
         }
 
         a {
-            color: #66ccff;
-            text-decoration: none;
+            color: #7ab8ff;
         }
 
         a:hover {
-            color: #99e6ff;
-            text-decoration: underline;
+            color: #a4d4ff;
         }
 
         .mark-btn {
-            background-color: #88888800;
-            border: none;
-            color: #f0da00;
-            font-size: 15px;
+            background-color: transparent;
+            border: 1px solid #ffd54f;
+            color: #ffd54f;
+            font-size: 14px;
             padding: 4px 8px;
-            border-radius: 2px;
+            border-radius: 3px;
             cursor: pointer;
-            margin-left: 8px;
         }
 
         .mark-btn:hover {
-            background-color: #0000001f;
+            background-color: rgba(255, 213, 79, 0.15);
         }
 
         .comment-text {
-            color: #ccc;
+            color: #c4c8e6;
             font-size: 12px;
         }
     </style>
 </head>
-<meta charset="UFC-8">
 <body>
-    <!-- Bookmarks Section -->
-    <div class="section-header">
-        <h2>Bookmarked Events <span id="bookmarkCount">(0)</span></h2>
-    </div>
-    <table id="bookmarkTable">
-        <thead>
-            <tr>
-                <th>Event Type</th>
-                <th>Truck Number</th>
-                <th>Timestamp</th>
-                <th>Page URL</th>
-                <th>Comment</th>
-            </tr>
-        </thead>
-        <tbody id="bookmarkBody"></tbody>
-    </table>
+    <nav class="top-nav">
+        <button data-nav-target="call-validation.html">Call Validation</button>
+        <button data-nav-target="settings.html">Settings</button>
+        <button data-nav-target="log.html">Event Log</button>
+        <button data-nav-target="site-info.html">Site Info</button>
+    </nav>
+    <main>
+        <section class="section-card">
+            <div class="section-header">
+                <h2>Bookmarked Events <span id="bookmarkCount">(0)</span></h2>
+            </div>
+            <div class="table-container">
+                <table id="bookmarkTable">
+                    <thead>
+                        <tr>
+                            <th>Event Type</th>
+                            <th>Truck Number</th>
+                            <th>Timestamp</th>
+                            <th>Page URL</th>
+                            <th>Comment</th>
+                        </tr>
+                    </thead>
+                    <tbody id="bookmarkBody"></tbody>
+                </table>
+            </div>
+        </section>
 
-    <!-- Controls -->
-    <div class="section-header">
-        <h2>Recorded Events <span id="eventCount">(Watched 0 Events)</span></h2>
-        <div class="button-group">
-            <button id="exportCSV">Export to CSV</button>
-            <button id="clearLogs">Clear Logs</button>
-        </div>
-    </div>
-
-    <input type="text" id="filterInput" placeholder="Search events...">
-
-    <table>
-        <thead>
-            <tr>
-                <th>Event Type</th>
-                <th>Truck Number</th>
-                <th>Timestamp</th>
-                <th>Page URL</th>
-            </tr>
-        </thead>
-        <tbody id="logTableBody"></tbody>
-    </table>
-
+        <section class="section-card">
+            <div class="section-header">
+                <h2>Recorded Events <span id="eventCount">(Watched 0 Events)</span></h2>
+                <div class="button-group">
+                    <button class="secondary" id="exportCSV">Export CSV</button>
+                    <button class="secondary danger" id="clearLogs">Clear Logs</button>
+                </div>
+            </div>
+            <input type="text" id="filterInput" class="filter-input" placeholder="Search events...">
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Event Type</th>
+                            <th>Truck Number</th>
+                            <th>Timestamp</th>
+                            <th>Page URL</th>
+                        </tr>
+                    </thead>
+                    <tbody id="logTableBody"></tbody>
+                </table>
+            </div>
+        </section>
+    </main>
+    <script src="navigation.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            initNavigation('log.html');
+        });
+    </script>
     <script src="log.js"></script>
 </body>
-
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,7 @@
     ],
     "browser_action": {
         "default_popup": "popup.html",
-        "default_icon": "icon.png"
+        "default_icon": "off.png"
     },
-    "options_page": "log.html"
+    "options_page": "settings.html"
 }

--- a/navigation.js
+++ b/navigation.js
@@ -1,0 +1,16 @@
+function initNavigation(activePage) {
+    const navButtons = document.querySelectorAll('[data-nav-target]');
+    navButtons.forEach((button) => {
+        const target = button.getAttribute('data-nav-target');
+        if (target === activePage) {
+            button.classList.add('active');
+        }
+        button.addEventListener('click', () => {
+            const url = chrome.runtime.getURL(target);
+            if (window.location.href === url) {
+                return;
+            }
+            window.location.href = url;
+        });
+    });
+}

--- a/popup.html
+++ b/popup.html
@@ -3,14 +3,14 @@
 <head>
     <title>QA Assist</title>
     <style>
-        body { 
-            width: 230px; 
-            font-family: Arial, sans-serif; 
-            text-align: center; 
+        body {
+            width: 260px;
+            font-family: Arial, sans-serif;
+            text-align: center;
             background-color: #222;
             color: #fff;
-            padding: 10px;
-            border-radius: 5px;
+            padding: 12px 10px 16px;
+            border-radius: 8px;
             position: relative;
         }
 
@@ -37,7 +37,7 @@
         }
 
         #status {
-            margin-top: 10px; 
+            margin-top: 10px;
             font-weight: bold;
         }
 
@@ -49,43 +49,70 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
+            gap: 8px;
         }
 
         .dropdown-container div {
-            width: 48%;
+            width: 50%;
             text-align: left;
         }
 
-        #viewLogs {
-            margin-top: 15px;
-            padding: 8px;
-            width: 100%;
-            background-color: #007bff;
-            color: white;
-            border: none;
-            border-radius: 5px;
-            cursor: pointer;
-            font-size: 14px;
-        }
-
-        #viewLogs:hover {
-            background-color: #3399ff;
-        }
-
-        /* Status Icon */
         #statusIcon {
             position: absolute;
-            top: 5px;
-            right: 5px;
-            width: 48px;
-            height: 48px;
+            top: 8px;
+            right: 10px;
+            width: 40px;
+            height: 40px;
+        }
+
+        .app-header {
+            display: flex;
+            align-items: center;
+            justify-content: flex-start;
+            gap: 10px;
+            margin-bottom: 6px;
+        }
+
+        .app-header img {
+            width: 32px;
+            height: 32px;
+        }
+
+        .app-header h3 {
+            margin: 0;
+        }
+
+        .nav-button {
+            width: 100%;
+            margin-top: 8px;
+            padding: 8px 10px;
+            background-color: #2f3645;
+            border: 1px solid #4d5566;
+            color: #fff;
+            border-radius: 5px;
+            font-size: 13px;
+            cursor: pointer;
+            transition: background-color 0.2s ease;
+        }
+
+        .nav-button:hover {
+            background-color: #3f4a63;
+        }
+
+        .nav-buttons {
+            margin-top: 12px;
+            display: grid;
+            grid-template-columns: 1fr;
+            gap: 6px;
         }
     </style>
 </head>
 <body>
-    <h3>QA Assist</h3>
-    
-    <!-- Status Icon -->
+    <div class="app-header">
+        <img src="icon.png" alt="QA Assist Icon">
+        <h3>QA Assist</h3>
+    </div>
+
     <img id="statusIcon" src="off.png" alt="Status">
 
     <label>
@@ -127,8 +154,14 @@
 
     <p id="status">Status: <span id="statusText">Checking...</span></p>
 
-    <button id="viewLogs">View Logs</button>
+    <div class="nav-buttons">
+        <button class="nav-button" id="openCallValidation">Open Call Validation</button>
+        <button class="nav-button" id="openSettingsPage">Open Settings</button>
+        <button class="nav-button" id="viewLogs">Open Event Log</button>
+        <button class="nav-button" id="openSiteInfo">Open Site Info</button>
+    </div>
 
+    <script src="settings-controller.js"></script>
     <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,106 +1,35 @@
 document.addEventListener("DOMContentLoaded", function () {
-    let toggle = document.getElementById("toggle");
-    let speedSelect = document.getElementById("speed");
-    let keySelect = document.getElementById("keySelect");
-    let statusText = document.getElementById("statusText");
-    let statusIcon = document.getElementById("statusIcon"); // 48x48px Image for status
-    let autoPressNextToggle = document.getElementById("autoPressNext");
-    let removeEyeTrackerToggle = document.getElementById("removeEyeTracker");
-    let viewLogsButton = document.getElementById("viewLogs");
-    
-    // Load stored settings
-    chrome.storage.sync.get(["enabled", "playbackSpeed", "pressKey", "autoPressNext", "removeEyeTracker"], function (data) {
-        console.log("🔄 Loaded settings:", data);
-
-        toggle.checked = data.enabled ?? false;
-        speedSelect.value = data.playbackSpeed || "1"; 
-        keySelect.value = data.pressKey || "ArrowDown"; 
-        autoPressNextToggle.checked = data.autoPressNext ?? false;
-        removeEyeTrackerToggle.checked = data.removeEyeTracker ?? false;
-
-        updateStatus(toggle.checked);
+    SettingsController.setup({
+        toggleId: "toggle",
+        speedSelectId: "speed",
+        keySelectId: "keySelect",
+        autoPressNextId: "autoPressNext",
+        removeEyeTrackerId: "removeEyeTracker",
+        statusTextId: "statusText",
+        statusIconId: "statusIcon",
+        viewLogsButtonId: "viewLogs",
+        onOpenLogs: () => {
+            chrome.tabs.create({ url: chrome.runtime.getURL("log.html") });
+        },
     });
 
-    // Function to update status text and icon
-    function updateStatus(isEnabled) {
-        statusText.textContent = isEnabled ? "Enabled" : "Disabled";
-        statusText.style.color = isEnabled ? "green" : "red";
-        statusIcon.src = isEnabled ? "on.png" : "off.png"; // Change icon
+    function openPage(page) {
+        chrome.tabs.create({ url: chrome.runtime.getURL(page) });
     }
 
-    // Toggle switch event
-    toggle.addEventListener("change", function () {
-        let isEnabled = toggle.checked;
-        console.log("🔘 Toggling state to:", isEnabled);
+    const callValidationButton = document.getElementById("openCallValidation");
+    const settingsPageButton = document.getElementById("openSettingsPage");
+    const siteInfoButton = document.getElementById("openSiteInfo");
 
-        chrome.storage.sync.set({ enabled: isEnabled }, () => {
-            updateStatus(isEnabled);
-            chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-                if (tabs.length > 0) {
-                    chrome.tabs.sendMessage(tabs[0].id, { enabled: isEnabled });
-                }
-            });
-        });
-    });
+    if (callValidationButton) {
+        callValidationButton.addEventListener("click", () => openPage("call-validation.html"));
+    }
 
-    // Auto Press Next List Toggle
-    autoPressNextToggle.addEventListener("change", function () {
-        let isEnabled = autoPressNextToggle.checked;
-        console.log("🔄 Auto Press Next List:", isEnabled);
+    if (settingsPageButton) {
+        settingsPageButton.addEventListener("click", () => openPage("settings.html"));
+    }
 
-        chrome.storage.sync.set({ autoPressNext: isEnabled }, () => {
-            chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-                if (tabs.length > 0) {
-                    chrome.tabs.sendMessage(tabs[0].id, { autoPressNext: isEnabled });
-                }
-            });
-        });
-    });
-
-    // Remove Eye Tracker Toggle
-    removeEyeTrackerToggle.addEventListener("change", function () {
-        let isEnabled = removeEyeTrackerToggle.checked;
-        console.log("👀 Remove Eye Tracker:", isEnabled);
-
-        chrome.storage.sync.set({ removeEyeTracker: isEnabled }, () => {
-            chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-                if (tabs.length > 0) {
-                    chrome.tabs.sendMessage(tabs[0].id, { removeEyeTracker: isEnabled });
-                }
-            });
-        });
-    });
-
-    // Speed selection event
-    speedSelect.addEventListener("change", function () {
-        let selectedSpeed = speedSelect.value;
-        console.log("⚡ Speed changed to:", selectedSpeed);
-
-        chrome.storage.sync.set({ playbackSpeed: selectedSpeed }, () => {
-            chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-                if (tabs.length > 0) {
-                    chrome.tabs.sendMessage(tabs[0].id, { playbackSpeed: selectedSpeed });
-                }
-            });
-        });
-    });
-
-    // Key selection event
-    keySelect.addEventListener("change", function () {
-        let selectedKey = keySelect.value;
-        console.log("🎯 Key changed to:", selectedKey);
-
-        chrome.storage.sync.set({ pressKey: selectedKey }, () => {
-            chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-                if (tabs.length > 0) {
-                    chrome.tabs.sendMessage(tabs[0].id, { pressKey: selectedKey });
-                }
-            });
-        });
-    });
-
-    // Open log.html when clicking "View Logs" button
-    viewLogsButton.addEventListener("click", function () {
-        chrome.tabs.create({ url: chrome.runtime.getURL("log.html") });
-    });
+    if (siteInfoButton) {
+        siteInfoButton.addEventListener("click", () => openPage("site-info.html"));
+    }
 });

--- a/settings-controller.js
+++ b/settings-controller.js
@@ -1,0 +1,124 @@
+const SettingsController = (function () {
+    function setup(config) {
+        const {
+            toggleId,
+            speedSelectId,
+            keySelectId,
+            autoPressNextId,
+            removeEyeTrackerId,
+            statusTextId,
+            statusIconId,
+            viewLogsButtonId,
+            onOpenLogs,
+        } = config;
+
+        const toggle = document.getElementById(toggleId);
+        const speedSelect = document.getElementById(speedSelectId);
+        const keySelect = document.getElementById(keySelectId);
+        const statusText = document.getElementById(statusTextId);
+        const statusIcon = document.getElementById(statusIconId);
+        const autoPressNextToggle = document.getElementById(autoPressNextId);
+        const removeEyeTrackerToggle = document.getElementById(removeEyeTrackerId);
+        const viewLogsButton = viewLogsButtonId ? document.getElementById(viewLogsButtonId) : null;
+
+        if (!toggle || !speedSelect || !keySelect) {
+            console.warn("SettingsController: Missing required elements");
+            return;
+        }
+
+        function updateStatus(isEnabled) {
+            if (statusText) {
+                statusText.textContent = isEnabled ? "Enabled" : "Disabled";
+                statusText.style.color = isEnabled ? "#00d26a" : "#ff5252";
+            }
+            if (statusIcon) {
+                statusIcon.src = isEnabled ? "on.png" : "off.png";
+            }
+            if (typeof chrome !== "undefined" && chrome.browserAction) {
+                chrome.browserAction.setIcon({ path: isEnabled ? "on.png" : "off.png" });
+            }
+        }
+
+        function sendMessage(payload) {
+            if (typeof chrome === "undefined" || !chrome.tabs || !chrome.tabs.query) {
+                return;
+            }
+            chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+                if (tabs.length > 0) {
+                    chrome.tabs.sendMessage(tabs[0].id, payload);
+                }
+            });
+        }
+
+        chrome.storage.sync.get([
+            "enabled",
+            "playbackSpeed",
+            "pressKey",
+            "autoPressNext",
+            "removeEyeTracker",
+        ], function (data) {
+            toggle.checked = typeof data.enabled === "boolean" ? data.enabled : false;
+            speedSelect.value = data.playbackSpeed || "1";
+            keySelect.value = data.pressKey || "ArrowDown";
+            if (autoPressNextToggle) {
+                autoPressNextToggle.checked = typeof data.autoPressNext === "boolean" ? data.autoPressNext : false;
+            }
+            if (removeEyeTrackerToggle) {
+                removeEyeTrackerToggle.checked = typeof data.removeEyeTracker === "boolean" ? data.removeEyeTracker : false;
+            }
+            updateStatus(toggle.checked);
+        });
+
+        toggle.addEventListener("change", function () {
+            const isEnabled = toggle.checked;
+            chrome.storage.sync.set({ enabled: isEnabled }, function () {
+                updateStatus(isEnabled);
+                sendMessage({ enabled: isEnabled });
+            });
+        });
+
+        speedSelect.addEventListener("change", function () {
+            const selectedSpeed = speedSelect.value;
+            chrome.storage.sync.set({ playbackSpeed: selectedSpeed }, function () {
+                sendMessage({ playbackSpeed: selectedSpeed });
+            });
+        });
+
+        keySelect.addEventListener("change", function () {
+            const selectedKey = keySelect.value;
+            chrome.storage.sync.set({ pressKey: selectedKey }, function () {
+                sendMessage({ pressKey: selectedKey });
+            });
+        });
+
+        if (autoPressNextToggle) {
+            autoPressNextToggle.addEventListener("change", function () {
+                const isEnabled = autoPressNextToggle.checked;
+                chrome.storage.sync.set({ autoPressNext: isEnabled }, function () {
+                    sendMessage({ autoPressNext: isEnabled });
+                });
+            });
+        }
+
+        if (removeEyeTrackerToggle) {
+            removeEyeTrackerToggle.addEventListener("change", function () {
+                const isEnabled = removeEyeTrackerToggle.checked;
+                chrome.storage.sync.set({ removeEyeTracker: isEnabled }, function () {
+                    sendMessage({ removeEyeTracker: isEnabled });
+                });
+            });
+        }
+
+        if (viewLogsButton && typeof onOpenLogs === "function") {
+            viewLogsButton.addEventListener("click", onOpenLogs);
+        }
+
+        return {
+            updateStatus,
+        };
+    }
+
+    return {
+        setup,
+    };
+})();

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>QA Assist - Settings</title>
+    <link rel="stylesheet" href="styles/common.css">
+    <style>
+        .settings-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 20px;
+        }
+
+        .toggle-row {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            margin-top: 12px;
+        }
+
+        .status-indicator {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            margin-bottom: 16px;
+        }
+
+        .status-indicator img {
+            width: 48px;
+            height: 48px;
+        }
+
+        select {
+            width: 100%;
+        }
+    </style>
+</head>
+<body>
+    <nav class="top-nav">
+        <button data-nav-target="call-validation.html">Call Validation</button>
+        <button data-nav-target="settings.html">Settings</button>
+        <button data-nav-target="log.html">Event Log</button>
+        <button data-nav-target="site-info.html">Site Info</button>
+    </nav>
+    <main>
+        <section class="section-card">
+            <div class="status-indicator">
+                <img id="statusIcon" src="off.png" alt="Status Icon">
+                <div>
+                    <h2>QA Assist Settings</h2>
+                    <p>Status: <strong id="statusText">Disabled</strong></p>
+                </div>
+            </div>
+            <div class="settings-grid">
+                <div>
+                    <label for="toggle">Scanning Mode</label>
+                    <div class="toggle-row">
+                        <span>Activate automation</span>
+                        <input type="checkbox" id="toggle">
+                    </div>
+                </div>
+                <div>
+                    <label for="speed">Playback Speed</label>
+                    <select id="speed">
+                        <option value="1">1x</option>
+                        <option value="1.25">1.25x</option>
+                        <option value="1.5">1.5x</option>
+                        <option value="2">2x</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="keySelect">Advance Key</label>
+                    <select id="keySelect">
+                        <option value="ArrowRight">OAS</option>
+                        <option value="ArrowDown">OpWeb</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="autoPressNext">Auto Press Next (OpWeb only)</label>
+                    <input type="checkbox" id="autoPressNext">
+                </div>
+                <div>
+                    <label for="removeEyeTracker">Remove Eye Tracker Overlay</label>
+                    <input type="checkbox" id="removeEyeTracker">
+                </div>
+            </div>
+            <div style="margin-top: 20px;">
+                <button class="secondary" id="viewLogs">Open Event Log</button>
+            </div>
+        </section>
+    </main>
+    <script src="navigation.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            initNavigation('settings.html');
+        });
+    </script>
+    <script src="settings-controller.js"></script>
+    <script src="settings.js"></script>
+</body>
+</html>

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', function () {
+    SettingsController.setup({
+        toggleId: 'toggle',
+        speedSelectId: 'speed',
+        keySelectId: 'keySelect',
+        autoPressNextId: 'autoPressNext',
+        removeEyeTrackerId: 'removeEyeTracker',
+        statusTextId: 'statusText',
+        statusIconId: 'statusIcon',
+        viewLogsButtonId: 'viewLogs',
+        onOpenLogs: function () {
+            window.location.href = chrome.runtime.getURL('log.html');
+        },
+    });
+});

--- a/site-info.html
+++ b/site-info.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>QA Assist - Site Info</title>
+    <link rel="stylesheet" href="styles/common.css">
+    <style>
+        .notes-cell {
+            color: #c4c8e6;
+            font-size: 13px;
+        }
+
+        .address-link {
+            color: #7ab8ff;
+        }
+
+        .address-link:hover {
+            color: #a4d4ff;
+        }
+    </style>
+</head>
+<body>
+    <nav class="top-nav">
+        <button data-nav-target="call-validation.html">Call Validation</button>
+        <button data-nav-target="settings.html">Settings</button>
+        <button data-nav-target="log.html">Event Log</button>
+        <button data-nav-target="site-info.html">Site Info</button>
+    </nav>
+    <main>
+        <section class="section-card">
+            <h2>Site Directory</h2>
+            <input type="text" id="siteSearch" class="filter-input" placeholder="Search sites by name or address">
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Site Name</th>
+                            <th>Address</th>
+                            <th>Notes</th>
+                        </tr>
+                    </thead>
+                    <tbody id="siteListBody"></tbody>
+                </table>
+            </div>
+            <div class="status-message" id="siteStatus"></div>
+        </section>
+    </main>
+    <script src="navigation.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            initNavigation('site-info.html');
+        });
+    </script>
+    <script src="site-info.js"></script>
+</body>
+</html>

--- a/site-info.js
+++ b/site-info.js
@@ -1,0 +1,127 @@
+(function () {
+    document.addEventListener('DOMContentLoaded', function () {
+        const tableBody = document.getElementById('siteListBody');
+        const searchInput = document.getElementById('siteSearch');
+        const statusMessage = document.getElementById('siteStatus');
+
+        let sites = [];
+
+        function setStatus(message, isError) {
+            if (!statusMessage) {
+                return;
+            }
+            statusMessage.textContent = message || '';
+            statusMessage.style.color = isError ? '#ff9090' : '#8fd18b';
+        }
+
+        function parseSites(text) {
+            const lines = text.split(/\r?\n/);
+            const parsed = [];
+            lines.forEach(function (line) {
+                const trimmed = line.trim();
+                if (!trimmed) {
+                    return;
+                }
+                const hostMatch = trimmed.match(/(https?:\/\/[^\s]+|\(?\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?\)?)/);
+                if (!hostMatch) {
+                    return;
+                }
+                const hostRaw = hostMatch[1].replace(/[()]/g, '');
+                const name = trimmed.slice(0, hostMatch.index).trim();
+                const rest = trimmed.slice(hostMatch.index + hostMatch[1].length).trim();
+
+                let url = hostRaw;
+                if (!/^https?:\/\//i.test(hostRaw)) {
+                    if (/^\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?$/.test(hostRaw)) {
+                        url = 'http://' + hostRaw;
+                    } else {
+                        url = 'https://' + hostRaw;
+                    }
+                }
+
+                parsed.push({
+                    name: name || hostRaw,
+                    address: hostRaw,
+                    url: url,
+                    note: rest,
+                });
+            });
+            return parsed;
+        }
+
+        function render(filterText) {
+            tableBody.innerHTML = '';
+            const keyword = (filterText || '').toLowerCase();
+            const filtered = sites.filter(function (site) {
+                if (!keyword) {
+                    return true;
+                }
+                return (
+                    site.name.toLowerCase().indexOf(keyword) !== -1 ||
+                    site.address.toLowerCase().indexOf(keyword) !== -1 ||
+                    (site.note && site.note.toLowerCase().indexOf(keyword) !== -1)
+                );
+            });
+
+            if (!filtered.length) {
+                const row = document.createElement('tr');
+                const cell = document.createElement('td');
+                cell.colSpan = 3;
+                cell.className = 'table-empty';
+                cell.textContent = 'No matching sites found.';
+                row.appendChild(cell);
+                tableBody.appendChild(row);
+                return;
+            }
+
+            filtered.forEach(function (site) {
+                const row = document.createElement('tr');
+                const nameCell = document.createElement('td');
+                nameCell.textContent = site.name;
+
+                const addressCell = document.createElement('td');
+                const link = document.createElement('a');
+                link.href = site.url;
+                link.textContent = site.address;
+                link.className = 'address-link';
+                link.target = '_blank';
+                addressCell.appendChild(link);
+
+                const notesCell = document.createElement('td');
+                notesCell.className = 'notes-cell';
+                notesCell.textContent = site.note || '';
+
+                row.appendChild(nameCell);
+                row.appendChild(addressCell);
+                row.appendChild(notesCell);
+                tableBody.appendChild(row);
+            });
+        }
+
+        if (searchInput) {
+            searchInput.addEventListener('input', function () {
+                render(searchInput.value);
+            });
+        }
+
+        fetch(chrome.runtime.getURL('sitelist.txt'))
+            .then(function (response) {
+                if (!response.ok) {
+                    throw new Error('Unable to load site list');
+                }
+                return response.text();
+            })
+            .then(function (text) {
+                sites = parseSites(text);
+                if (!sites.length) {
+                    setStatus('Site list is empty.', true);
+                } else {
+                    setStatus('Loaded ' + sites.length + ' sites.');
+                }
+                render('');
+            })
+            .catch(function () {
+                setStatus('Failed to load site information.', true);
+            });
+    });
+})();

--- a/styles/common.css
+++ b/styles/common.css
@@ -1,0 +1,167 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #1f1f27;
+    color: #f1f1f1;
+    margin: 0;
+    padding: 0;
+}
+
+main {
+    padding: 24px;
+}
+
+.top-nav {
+    display: flex;
+    gap: 12px;
+    padding: 16px 24px 0 24px;
+}
+
+.top-nav button {
+    background-color: #2f3645;
+    border: 1px solid #4d5566;
+    color: #ffffff;
+    padding: 10px 18px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.top-nav button:hover {
+    background-color: #3f4a63;
+    border-color: #5b6780;
+}
+
+.top-nav button.active {
+    background-color: #5b7aea;
+    border-color: #7a8cff;
+    color: #ffffff;
+}
+
+.section-card {
+    background-color: #292f3f;
+    border: 1px solid #3d4457;
+    border-radius: 8px;
+    padding: 20px;
+    margin-bottom: 24px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+}
+
+.section-card h2 {
+    margin-top: 0;
+    margin-bottom: 12px;
+    color: #ffffff;
+}
+
+label {
+    display: block;
+    margin-bottom: 6px;
+    color: #d3d7f7;
+}
+
+input, select, textarea {
+    width: 100%;
+    padding: 8px;
+    border-radius: 4px;
+    border: 1px solid #4d5566;
+    background-color: #1f2433;
+    color: #ffffff;
+    box-sizing: border-box;
+}
+
+input:focus, select:focus, textarea:focus {
+    outline: none;
+    border-color: #5b7aea;
+    box-shadow: 0 0 0 2px rgba(91, 122, 234, 0.25);
+}
+
+.table-container {
+    overflow-x: auto;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 12px;
+}
+
+table thead {
+    background-color: #353c50;
+}
+
+table th, table td {
+    border: 1px solid #444c63;
+    padding: 10px;
+    text-align: left;
+    font-size: 14px;
+}
+
+table tbody tr:nth-child(even) {
+    background-color: #262d3f;
+}
+
+table tbody tr:hover {
+    background-color: #323a50;
+}
+
+button.primary {
+    background-color: #5b7aea;
+    border: none;
+    color: #ffffff;
+    padding: 10px 16px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+button.primary:hover {
+    background-color: #6d87f0;
+}
+
+button.secondary {
+    background-color: transparent;
+    border: 1px solid #5b7aea;
+    color: #5b7aea;
+    padding: 10px 16px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+button.secondary:hover {
+    background-color: rgba(91, 122, 234, 0.1);
+}
+
+.status-message {
+    margin-top: 10px;
+    color: #8fd18b;
+    min-height: 18px;
+}
+
+.actions-cell {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.actions-cell button {
+    flex: 1 1 140px;
+}
+
+@media (max-width: 720px) {
+    main {
+        padding: 16px;
+    }
+
+    .top-nav {
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .top-nav button {
+        flex: 1 1 45%;
+    }
+
+    .actions-cell {
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
## Summary
- refresh the popup to highlight QA Assist branding, add quick navigation buttons, and switch the browser action icon between on/off states
- capture validation details from the page, persist the latest event metadata, and introduce a full call validation workspace with per-column outputs and targeted copy helpers
- restore the settings experience and add a searchable site directory, tying every page together with shared navigation and styling

## Testing
- not run (extension-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d462b338a48323ab458a58847b47e2