### PR TITLE
Add configurable validation filter and confirm destructive actions

### DIFF
--- a/content.js
+++ b/content.js
@@ -7,8 +7,218 @@ let activeOverride = null;
 const processedEventKeys = new Set();
 let mutationObserver = null;
 
+const DEFAULT_VALIDATION_VOCABULARY = [
+    { label: "Blocked", keywords: ["blocked"] },
+    { label: "Critical", keywords: ["critical"] },
+    { label: "Moderate", keywords: ["moderate"] },
+    { label: "3 Low/hr", keywords: ["low"] },
+    { label: "Cellphone", keywords: ["cell phone", "cellphone", "cell", "phone"] },
+    { label: "False Positive", keywords: ["false", "non"] },
+    { label: "Lost Connection", keywords: ["lost connection", "lost", "disconnect"] },
+];
+
+let validationVocabulary = cloneDefaultVocabulary();
+let validationFilterEnabled = true;
+let validationMatchers = buildValidationMatchers(validationVocabulary);
+
 function getPageUrl() {
     return window.location.href.split("#")[0];
+}
+
+function cloneDefaultVocabulary() {
+    return DEFAULT_VALIDATION_VOCABULARY.map((entry) => ({
+        label: entry.label,
+        keywords: Array.isArray(entry.keywords) ? [...entry.keywords] : [],
+    }));
+}
+
+function sanitizeVocabularyInput(input) {
+    if (!Array.isArray(input)) {
+        return cloneDefaultVocabulary();
+    }
+
+    const seen = new Set();
+    const sanitized = input
+        .map((entry) => {
+            const label = String(entry?.label || "").trim();
+            if (!label) {
+                return null;
+            }
+
+            const lowerLabel = label.toLowerCase();
+            if (seen.has(lowerLabel)) {
+                return null;
+            }
+
+            const keywordSource = Array.isArray(entry?.keywords)
+                ? entry.keywords
+                : typeof entry?.keywords === "string"
+                    ? entry.keywords.split(",")
+                    : [];
+
+            const keywords = Array.from(
+                new Set(
+                    keywordSource
+                        .concat(label)
+                        .map((keyword) => String(keyword || "").trim())
+                        .filter(Boolean),
+                ),
+            );
+
+            seen.add(lowerLabel);
+            return { label, keywords };
+        })
+        .filter(Boolean);
+
+    return sanitized.length ? sanitized : cloneDefaultVocabulary();
+}
+
+function escapeRegExp(value) {
+    return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function buildValidationMatchers(list) {
+    return list.map((entry) => {
+        const keywords = Array.isArray(entry.keywords) ? entry.keywords : [];
+        const normalizedKeywords = Array.from(
+            new Set(keywords.concat(entry.label).map((keyword) => String(keyword || "").trim()).filter(Boolean)),
+        );
+
+        const regexes = normalizedKeywords
+            .map((keyword) => {
+                if (!keyword) {
+                    return null;
+                }
+                if (/^[\w\s]+$/.test(keyword)) {
+                    return new RegExp(`\\b${escapeRegExp(keyword)}\\b`, "i");
+                }
+                return null;
+            })
+            .filter(Boolean);
+
+        const lowerKeywords = normalizedKeywords.map((keyword) => keyword.toLowerCase());
+
+        return {
+            label: entry.label,
+            regexes,
+            lowerKeywords,
+        };
+    });
+}
+
+function findValidationLabel(text) {
+    const cleaned = String(text || "").trim();
+    if (!cleaned) {
+        return "";
+    }
+
+    const lower = cleaned.toLowerCase();
+
+    for (const matcher of validationMatchers) {
+        if (matcher.regexes.some((regex) => regex.test(cleaned))) {
+            return matcher.label;
+        }
+
+        if (matcher.lowerKeywords.some((keyword) => keyword && lower.includes(keyword))) {
+            return matcher.label;
+        }
+    }
+
+    return "";
+}
+
+function applyValidationPreferences(rawList, filterEnabled) {
+    validationVocabulary = sanitizeVocabularyInput(rawList);
+    validationFilterEnabled = typeof filterEnabled === "boolean" ? filterEnabled : true;
+    validationMatchers = buildValidationMatchers(validationVocabulary);
+}
+
+function normalizeValidationType(value) {
+    const text = String(value || "").trim();
+    if (!text) {
+        return "";
+    }
+
+    if (!validationFilterEnabled) {
+        return text;
+    }
+
+    const matched = findValidationLabel(text);
+    return matched || text;
+}
+
+function looksLikeValidationLabel(text) {
+    if (!text) {
+        return false;
+    }
+
+    const cleaned = String(text).trim();
+    if (!cleaned) {
+        return false;
+    }
+
+    if (findValidationLabel(cleaned)) {
+        return true;
+    }
+
+    return /validation/i.test(cleaned);
+}
+
+function cleanValidationText(text) {
+    if (!text) {
+        return "";
+    }
+
+    return String(text)
+        .replace(/validation\s*type\s*:?/gi, "")
+        .replace(/validation\s*:?/gi, "")
+        .replace(/type\s*:?/gi, "")
+        .replace(/\s+/g, " ")
+        .trim();
+}
+
+function extractValidationFromContainer(container) {
+    if (!container) {
+        return "";
+    }
+
+    const selectors = [
+        "label.field-validation_type",
+        "label.field-validationtype",
+        "label.field-validation",
+        "[data-field='validation_type']",
+        "[data-name='validation_type']",
+        ".validation-type",
+        ".field-validation_type",
+        ".field-validation",
+    ];
+
+    for (const selector of selectors) {
+        const node = container.querySelector(selector);
+        if (node && node.textContent) {
+            const cleaned = cleanValidationText(node.textContent);
+            if (cleaned) {
+                return cleaned;
+            }
+        }
+    }
+
+    const candidates = Array.from(container.querySelectorAll("label, span, div, p, strong"));
+    for (const node of candidates) {
+        const text = node?.textContent || "";
+        if (!text) {
+            continue;
+        }
+        if (!/validation/i.test(text)) {
+            continue;
+        }
+        const cleaned = cleanValidationText(text);
+        if (cleaned) {
+            return cleaned;
+        }
+    }
+
+    return "";
 }
 
 function collectEventDetails(video) {
@@ -22,6 +232,7 @@ function collectEventDetails(video) {
     let eventId = "";
     const pageUrl = getPageUrl();
     let isLastCell = false;
+    let validationType = "";
 
     if (isHideTracking) {
         const selectedItem = document.querySelector(".item.selected");
@@ -40,13 +251,19 @@ function collectEventDetails(video) {
             if (eventIdElement) {
                 eventId = eventIdElement.textContent.trim();
             }
+
+            validationType = extractValidationFromContainer(selectedItem);
         }
     } else if (selectedRow) {
         isLastCell = selectedRow === allRows[allRows.length - 1];
 
-        const eventTypeElement = selectedRow.querySelector(".gvEventListItemRight[style*='color']");
         const truckNumberElements = selectedRow.querySelectorAll(".gvEventListItemLeft");
         const timestampElement = selectedRow.querySelector(".gvEventListItemRight[style*='width: 90%']");
+        const rightSideElements = Array.from(selectedRow.querySelectorAll(".gvEventListItemRight"))
+            .filter((node) => {
+                const styleAttr = (node.getAttribute("style") || "").toLowerCase();
+                return styleAttr.includes("color");
+            });
 
         if (truckNumberElements.length > 0) {
             eventId = (truckNumberElements[0]?.textContent || "").trim();
@@ -54,16 +271,43 @@ function collectEventDetails(video) {
         if (truckNumberElements.length > 1) {
             truckNumber = (truckNumberElements[1]?.textContent || "").trim();
         }
-        if (eventTypeElement) {
-            eventType = eventTypeElement.textContent.trim();
+        if (rightSideElements.length) {
+            const primary = (rightSideElements[0]?.textContent || "").trim();
+            if (primary) {
+                eventType = primary;
+            }
+
+            const secondary = rightSideElements
+                .slice(1)
+                .map((node) => (node?.textContent || "").trim())
+                .find((text) => looksLikeValidationLabel(text));
+
+            if (secondary) {
+                validationType = secondary;
+            }
         }
         if (timestampElement) {
             timestamp = timestampElement.textContent.trim();
+        }
+
+        if (!validationType) {
+            validationType = extractValidationFromContainer(selectedRow);
         }
     } else {
         console.warn("⚠️ No selected row found for event logging.");
         return null;
     }
+
+    if (!validationType) {
+        const detailsPanel =
+            document.querySelector(".gvDetailPanel, .gvEventDetails, .event-details, .details-panel") ||
+            selectedRow?.parentElement ||
+            null;
+        validationType = extractValidationFromContainer(detailsPanel) || validationType;
+    }
+
+    const cleanedValidation = (validationType || "").trim();
+    const normalizedValidation = normalizeValidationType(cleanedValidation);
 
     const eventData = {
         eventType,
@@ -72,6 +316,8 @@ function collectEventDetails(video) {
         pageUrl,
         isLastCell,
         eventId,
+        validationType: normalizedValidation || cleanedValidation,
+        validationTypeRaw: cleanedValidation,
     };
 
     return eventData;
@@ -149,8 +395,14 @@ function registerEventLog(eventData) {
     processedEventKeys.add(eventKey);
 
     resolveSiteName(eventData.pageUrl).then(({ siteName, siteMatchValue }) => {
+        const rawValidation = eventData.validationTypeRaw || eventData.validationType || "";
+        const normalizedValidation = normalizeValidationType(rawValidation);
         const enrichedEvent = {
             ...eventData,
+            validationTypeRaw: rawValidation,
+            validationTypeDetected: rawValidation,
+            detectedValidation: rawValidation,
+            validationType: normalizedValidation,
             siteName,
             siteMatchValue,
             createdAt: new Date().toISOString(),
@@ -335,8 +587,18 @@ function applyOverrideSettings(override) {
 
 function loadSettingsAndInitialize() {
     chrome.storage.sync.get(
-        ["enabled", "playbackSpeed", "pressKey", "autoPressNext", "removeEyeTracker", "siteOverrides"],
+        [
+            "enabled",
+            "playbackSpeed",
+            "pressKey",
+            "autoPressNext",
+            "removeEyeTracker",
+            "siteOverrides",
+            "validationVocabulary",
+            "validationFilterEnabled",
+        ],
         (data) => {
+            applyValidationPreferences(data.validationVocabulary, data.validationFilterEnabled);
             isEnabled = data.enabled || false;
             playbackSpeed = parseFloat(data.playbackSpeed) || 1.0;
             pressKey = data.pressKey || "ArrowDown";
@@ -391,6 +653,27 @@ chrome.runtime.onMessage.addListener((request) => {
     if (request.siteOverrides) {
         const override = findOverrideForUrl(window.location.href, request.siteOverrides);
         applyOverrideSettings(override);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(request, "validationVocabulary") ||
+        Object.prototype.hasOwnProperty.call(request, "validationFilterEnabled")) {
+        applyValidationPreferences(request.validationVocabulary, request.validationFilterEnabled);
+    }
+});
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName !== "sync") {
+        return;
+    }
+
+    const vocabChange = changes.validationVocabulary;
+    const filterChange = changes.validationFilterEnabled;
+
+    if (vocabChange || filterChange) {
+        applyValidationPreferences(
+            vocabChange ? vocabChange.newValue : validationVocabulary,
+            filterChange ? filterChange.newValue : validationFilterEnabled,
+        );
     }
 });
 

--- a/log.html
+++ b/log.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Project Time Weaver · Event Log</title>
+    <title>QA Assist · Event Log</title>
     <style>
         :root {
             color-scheme: dark;
@@ -28,6 +28,32 @@
             color: var(--text);
             font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
             padding: 32px 36px 48px;
+        }
+
+        .top-nav {
+            display: inline-flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-bottom: 24px;
+        }
+
+        .top-nav a {
+            padding: 8px 14px;
+            border-radius: 999px;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            background: rgba(255, 255, 255, 0.06);
+            color: var(--text);
+            text-decoration: none;
+            font-size: 13px;
+            font-weight: 600;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        .top-nav a:hover,
+        .top-nav a:focus {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+            outline: none;
         }
 
         h1 {
@@ -178,6 +204,29 @@
             transform: scale(1.08);
         }
 
+        .toast {
+            position: fixed;
+            bottom: 24px;
+            left: 50%;
+            transform: translateX(-50%) translateY(120%);
+            background: rgba(12, 18, 30, 0.94);
+            color: var(--text);
+            padding: 12px 20px;
+            border-radius: 999px;
+            border: 1px solid rgba(76, 141, 255, 0.4);
+            box-shadow: 0 18px 42px rgba(0, 0, 0, 0.4);
+            opacity: 0;
+            transition: opacity 0.25s ease, transform 0.25s ease;
+            pointer-events: none;
+            font-weight: 600;
+            z-index: 900;
+        }
+
+        .toast.show {
+            opacity: 1;
+            transform: translateX(-50%) translateY(0);
+        }
+
         .badge {
             display: inline-flex;
             align-items: center;
@@ -221,6 +270,10 @@
             position: relative;
         }
 
+        .modal-card.compact {
+            width: min(420px, 100%);
+        }
+
         .modal-card h3 {
             margin: 0 0 6px;
             font-size: 22px;
@@ -229,6 +282,19 @@
         .modal-card .subtitle {
             color: var(--muted);
             margin-bottom: 20px;
+        }
+
+        .modal-card textarea {
+            width: 100%;
+            min-height: 110px;
+            border-radius: 12px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(12, 16, 26, 0.85);
+            color: var(--text);
+            padding: 12px 14px;
+            font-family: inherit;
+            font-size: 14px;
+            resize: vertical;
         }
 
         .close-modal {
@@ -339,6 +405,19 @@
             cursor: pointer;
         }
 
+        .modal-footer.bookmark-actions {
+            align-items: center;
+        }
+
+        .modal-footer.bookmark-actions .button-group {
+            display: flex;
+            gap: 12px;
+        }
+
+        .modal-footer.bookmark-actions button {
+            flex: initial;
+        }
+
         .modal-footer button.primary {
             background: linear-gradient(135deg, var(--accent), #6aa2ff);
             border-color: transparent;
@@ -364,6 +443,30 @@
             min-height: 80px;
         }
 
+        .copy-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-top: 12px;
+        }
+
+        .copy-actions button {
+            flex: 1 1 160px;
+            padding: 10px 14px;
+            border-radius: 12px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(255, 255, 255, 0.04);
+            color: var(--text);
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        .copy-actions button:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+        }
+
         .hidden {
             display: none !important;
         }
@@ -380,8 +483,15 @@
     </style>
 </head>
 <body>
+    <nav class="top-nav" aria-label="QA Assist navigation">
+        <a href="log.html">Event Log</a>
+        <a href="settings.html">Settings</a>
+        <a href="site-overrides.html">Site Overrides</a>
+        <a href="site-info.html">Site Info</a>
+    </nav>
+
     <header class="header">
-        <h1>Project Time Weaver — Event Log</h1>
+        <h1>QA Assist — Event Log</h1>
         <p>Review captured activity, manage bookmarks, and initiate call validations.</p>
     </header>
 
@@ -396,6 +506,7 @@
                     <th>Event</th>
                     <th>Truck</th>
                     <th>Timestamp</th>
+                    <th>Validation</th>
                     <th>Site</th>
                     <th>Page</th>
                     <th>Comment</th>
@@ -412,7 +523,7 @@
             <span id="eventCount" class="badge">0 items</span>
         </div>
         <div class="controls">
-            <input type="text" id="filterInput" placeholder="Search by event, truck, timestamp, site, or URL...">
+            <input type="text" id="filterInput" placeholder="Search by event, validation, truck, timestamp, site, or URL...">
             <button id="exportCSV" class="export">Export CSV</button>
             <button id="clearLogs">Clear Logs</button>
         </div>
@@ -425,6 +536,7 @@
                     <th>Timestamp</th>
                     <th>Site</th>
                     <th>Page URL</th>
+                    <th>Validation Type</th>
                     <th>Calls</th>
                     <th>Actions</th>
                 </tr>
@@ -483,6 +595,10 @@
                     <label for="tabOutput">Excel Row</label>
                     <textarea id="tabOutput" readonly></textarea>
                 </div>
+                <div class="copy-actions">
+                    <button id="copyEventTime">Only Copy Event Time</button>
+                    <button id="copyCallTime">Only Copy Call Time</button>
+                </div>
                 <button id="copyTabOutput" class="primary" style="width: 100%; margin-top: 12px;">Copy to Clipboard</button>
             </div>
 
@@ -492,6 +608,36 @@
             </div>
         </div>
     </div>
+
+    <div class="modal" id="bookmarkModal" aria-hidden="true">
+        <div class="modal-card compact">
+            <button class="close-modal" id="closeBookmarkModal" title="Close">×</button>
+            <h3>Bookmark Event</h3>
+            <p class="subtitle">Add an optional note to keep track of this event.</p>
+            <textarea id="bookmarkComment" placeholder="Add a quick note (optional)"></textarea>
+            <div class="modal-footer bookmark-actions">
+                <button type="button" id="bookmarkRemove" class="danger hidden">Remove Bookmark</button>
+                <div class="button-group">
+                    <button type="button" id="bookmarkCancel">Cancel</button>
+                    <button type="button" id="bookmarkSave" class="primary">Add Bookmark</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal" id="confirmModal" aria-hidden="true">
+        <div class="modal-card compact">
+            <button class="close-modal" id="closeConfirmModal" title="Close">×</button>
+            <h3>Confirm Action</h3>
+            <p class="subtitle" id="confirmMessage">Are you sure?</p>
+            <div class="modal-footer">
+                <button type="button" id="confirmCancel">Cancel</button>
+                <button type="button" id="confirmAccept" class="primary">Confirm</button>
+            </div>
+        </div>
+    </div>
+
+    <div class="toast" id="logToast" role="status" aria-live="polite"></div>
 
     <script src="log.js"></script>
 </body>

--- a/log.js
+++ b/log.js
@@ -1,4 +1,4 @@
-// Enhanced log.js for Project Time Weaver
+// Enhanced log.js for QA Assist
 
 document.addEventListener("DOMContentLoaded", () => {
     const logTableBody = document.getElementById("logTableBody");
@@ -32,9 +32,372 @@ document.addEventListener("DOMContentLoaded", () => {
     const tabOutput = document.getElementById("tabOutput");
     const callSummaryLeft = document.getElementById("callSummaryLeft");
     const callSummaryRight = document.getElementById("callSummaryRight");
+    const copyEventTimeButton = document.getElementById("copyEventTime");
+    const copyCallTimeButton = document.getElementById("copyCallTime");
+    const bookmarkModal = document.getElementById("bookmarkModal");
+    const bookmarkCommentInput = document.getElementById("bookmarkComment");
+    const bookmarkSaveButton = document.getElementById("bookmarkSave");
+    const bookmarkRemoveButton = document.getElementById("bookmarkRemove");
+    const bookmarkCancelButton = document.getElementById("bookmarkCancel");
+    const closeBookmarkModalButton = document.getElementById("closeBookmarkModal");
+    const confirmModal = document.getElementById("confirmModal");
+    const confirmMessage = document.getElementById("confirmMessage");
+    const confirmAcceptButton = document.getElementById("confirmAccept");
+    const confirmCancelButton = document.getElementById("confirmCancel");
+    const closeConfirmButton = document.getElementById("closeConfirmModal");
+    const logToast = document.getElementById("logToast");
+
+    const DEFAULT_VALIDATION_VOCABULARY = [
+        { label: "Blocked", keywords: ["blocked"] },
+        { label: "Critical", keywords: ["critical"] },
+        { label: "Moderate", keywords: ["moderate"] },
+        { label: "3 Low/hr", keywords: ["low"] },
+        { label: "Cellphone", keywords: ["cell phone", "cellphone", "cell", "phone"] },
+        { label: "False Positive", keywords: ["false", "non"] },
+        { label: "Lost Connection", keywords: ["lost connection", "lost", "disconnect"] },
+    ];
+
+    let validationVocabulary = cloneDefaultVocabulary();
+    let validationFilterEnabled = true;
+    let validationMatchers = buildValidationMatchers(validationVocabulary);
 
     let logs = [];
     let activeCallState = null;
+    let activeBookmarkId = null;
+    let confirmAction = null;
+    let toastTimeout = null;
+
+    function cloneDefaultVocabulary() {
+        return DEFAULT_VALIDATION_VOCABULARY.map((entry) => ({
+            label: entry.label,
+            keywords: Array.isArray(entry.keywords) ? [...entry.keywords] : [],
+        }));
+    }
+
+    function sanitizeVocabularyInput(input) {
+        if (!Array.isArray(input)) {
+            return cloneDefaultVocabulary();
+        }
+
+        const seen = new Set();
+        const sanitized = input
+            .map((entry) => {
+                const label = String(entry?.label || "").trim();
+                if (!label) {
+                    return null;
+                }
+
+                const lowerLabel = label.toLowerCase();
+                if (seen.has(lowerLabel)) {
+                    return null;
+                }
+
+                const keywordSource = Array.isArray(entry?.keywords)
+                    ? entry.keywords
+                    : typeof entry?.keywords === "string"
+                        ? entry.keywords.split(",")
+                        : [];
+
+                const keywords = Array.from(
+                    new Set(
+                        keywordSource
+                            .concat(label)
+                            .map((keyword) => String(keyword || "").trim())
+                            .filter(Boolean),
+                    ),
+                );
+
+                seen.add(lowerLabel);
+                return { label, keywords };
+            })
+            .filter(Boolean);
+
+        return sanitized.length ? sanitized : cloneDefaultVocabulary();
+    }
+
+    function escapeRegExp(value) {
+        return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    }
+
+    function buildValidationMatchers(list) {
+        return list.map((entry) => {
+            const keywords = Array.isArray(entry.keywords) ? entry.keywords : [];
+            const normalizedKeywords = Array.from(
+                new Set(keywords.concat(entry.label).map((keyword) => String(keyword || "").trim()).filter(Boolean)),
+            );
+
+            const regexes = normalizedKeywords
+                .map((keyword) => {
+                    if (!keyword) {
+                        return null;
+                    }
+                    if (/^[\w\s]+$/.test(keyword)) {
+                        return new RegExp(`\\b${escapeRegExp(keyword)}\\b`, "i");
+                    }
+                    return null;
+                })
+                .filter(Boolean);
+
+            const lowerKeywords = normalizedKeywords.map((keyword) => keyword.toLowerCase());
+
+            return {
+                label: entry.label,
+                regexes,
+                lowerKeywords,
+            };
+        });
+    }
+
+    function findValidationLabel(text) {
+        const cleaned = String(text || "").trim();
+        if (!cleaned) {
+            return "";
+        }
+
+        const lower = cleaned.toLowerCase();
+
+        for (const matcher of validationMatchers) {
+            if (matcher.regexes.some((regex) => regex.test(cleaned))) {
+                return matcher.label;
+            }
+
+            if (matcher.lowerKeywords.some((keyword) => keyword && lower.includes(keyword))) {
+                return matcher.label;
+            }
+        }
+
+        return "";
+    }
+
+    function applyValidationPreferences(rawList, filterEnabled) {
+        validationVocabulary = sanitizeVocabularyInput(rawList);
+        validationFilterEnabled = typeof filterEnabled === "boolean" ? filterEnabled : true;
+        validationMatchers = buildValidationMatchers(validationVocabulary);
+    }
+
+    function refreshValidationPreferences(rawList, filterEnabled) {
+        applyValidationPreferences(rawList, filterEnabled);
+        if (logs.length) {
+            logs = logs.map((entry) => ensureLogShape(entry)).filter(Boolean);
+            updateDisplays(logs);
+        }
+    }
+
+    function normalizeValidationType(value) {
+        const text = String(value || "").trim();
+        if (!text) {
+            return "";
+        }
+
+        if (!validationFilterEnabled) {
+            return text;
+        }
+
+        const matched = findValidationLabel(text);
+        return matched || text;
+    }
+
+    function extractHourMinuteFromDate(date) {
+        if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+            return { hour: "", minute: "" };
+        }
+
+        return {
+            hour: String(date.getHours()),
+            minute: String(date.getMinutes()),
+        };
+    }
+
+    function extractHourMinuteFromText(text) {
+        if (!text) {
+            return null;
+        }
+
+        const match = String(text)
+            .trim()
+            .match(/(\d{1,2}):(\d{2})(?::(\d{2}))?\s*(AM|PM)?/i);
+
+        if (!match) {
+            return null;
+        }
+
+        let hour = Number.parseInt(match[1], 10);
+        const minuteValue = Number.parseInt(match[2], 10);
+        if (Number.isNaN(hour) || Number.isNaN(minuteValue)) {
+            return null;
+        }
+
+        const meridiem = match[4] ? match[4].toUpperCase() : null;
+        if (meridiem === "PM" && hour < 12) {
+            hour += 12;
+        } else if (meridiem === "AM" && hour === 12) {
+            hour = 0;
+        }
+
+        return {
+            hour: String(hour),
+            minute: String(minuteValue),
+        };
+    }
+
+    function getEventTimeParts(log) {
+        if (!log) {
+            return { hour: "", minute: "" };
+        }
+
+        const fromTimestamp = extractHourMinuteFromText(log.timestamp);
+        if (fromTimestamp) {
+            return fromTimestamp;
+        }
+
+        const createdAt = log.createdAt ? new Date(log.createdAt) : null;
+        if (createdAt) {
+            return extractHourMinuteFromDate(createdAt);
+        }
+
+        return { hour: "", minute: "" };
+    }
+
+    function getCallTimeParts(callHistory) {
+        const safeHistory = Array.isArray(callHistory) ? callHistory : [];
+
+        return [0, 1, 2].map((index) => {
+            const entry = safeHistory[index];
+            if (!entry) {
+                return { hour: "", minute: "" };
+            }
+
+            const entryDate = entry.timestamp ? new Date(entry.timestamp) : null;
+            if (entryDate) {
+                const parts = extractHourMinuteFromDate(entryDate);
+                if (parts.hour || parts.minute) {
+                    return parts;
+                }
+            }
+
+            const fallback = extractHourMinuteFromText(entry.time || entry.tabRow || "");
+            return fallback || { hour: "", minute: "" };
+        });
+    }
+
+    function showToast(message) {
+        if (!logToast) {
+            return;
+        }
+
+        logToast.textContent = message;
+        logToast.classList.add("show");
+
+        if (toastTimeout) {
+            clearTimeout(toastTimeout);
+        }
+
+        toastTimeout = setTimeout(() => {
+            logToast.classList.remove("show");
+        }, 2200);
+    }
+
+    function setValidationButtonState(choice) {
+        validationYesButton.classList.toggle("active", choice === "yes");
+        validationNoButton.classList.toggle("active", choice === "no");
+    }
+
+    function resolveValidationValue(log) {
+        if (!log) {
+            return "";
+        }
+
+        const candidates = [
+            log.validationType,
+            log.finalValidation,
+            log.detectedValidation,
+            log.validationTypeDetected,
+            log.validationTypeRaw,
+        ];
+
+        for (const candidate of candidates) {
+            const text = (candidate || "").trim();
+            if (text) {
+                return text;
+            }
+        }
+
+        return "";
+    }
+
+    function closeBookmarkModal() {
+        if (!bookmarkModal) {
+            return;
+        }
+
+        bookmarkModal.classList.remove("show");
+        activeBookmarkId = null;
+        if (bookmarkCommentInput) {
+            bookmarkCommentInput.value = "";
+        }
+    }
+
+    function openBookmarkModal(log) {
+        if (!bookmarkModal || !log) {
+            return;
+        }
+
+        activeBookmarkId = log.id;
+        bookmarkModal.classList.add("show");
+
+        if (bookmarkCommentInput) {
+            bookmarkCommentInput.value = log.comment || "";
+            setTimeout(() => bookmarkCommentInput.focus(), 100);
+        }
+
+        if (bookmarkSaveButton) {
+            bookmarkSaveButton.textContent = log.bookmarked ? "Save Changes" : "Add Bookmark";
+        }
+
+        if (bookmarkRemoveButton) {
+            bookmarkRemoveButton.classList.toggle("hidden", !log.bookmarked);
+        }
+    }
+
+    function closeConfirmModal() {
+        if (!confirmModal) {
+            return;
+        }
+
+        confirmModal.classList.remove("show");
+        confirmAction = null;
+    }
+
+    function openConfirmModal(message, action) {
+        if (!confirmModal) {
+            if (typeof action === "function") {
+                action();
+            }
+            return;
+        }
+
+        if (confirmMessage) {
+            confirmMessage.textContent = message;
+        }
+        confirmModal.classList.add("show");
+        confirmAction = typeof action === "function" ? action : null;
+        if (confirmAcceptButton) {
+            setTimeout(() => confirmAcceptButton.focus(), 100);
+        }
+    }
+
+    function flashButtonFeedback(button, message, duration = 1200) {
+        if (!button) {
+            return;
+        }
+        const original = button.textContent;
+        button.textContent = message;
+        button.disabled = true;
+        setTimeout(() => {
+            button.textContent = original;
+            button.disabled = false;
+        }, duration);
+    }
 
     function generateId() {
         if (typeof crypto !== "undefined" && crypto.randomUUID) {
@@ -69,6 +432,26 @@ document.addEventListener("DOMContentLoaded", () => {
         shaped.callHistory = Array.isArray(shaped.callHistory) ? shaped.callHistory : [];
         shaped.eventKey = shaped.eventKey || createEventKey(shaped);
         shaped.id = shaped.id || generateId();
+        const detected =
+            shaped.validationTypeRaw ||
+            shaped.validationTypeDetected ||
+            shaped.detectedValidation ||
+            shaped.validationType ||
+            "";
+
+        const normalizedValidation = normalizeValidationType(shaped.validationType || detected);
+
+        if (!shaped.validationTypeRaw) {
+            shaped.validationTypeRaw = detected;
+        }
+        if (!shaped.validationTypeDetected) {
+            shaped.validationTypeDetected = detected;
+        }
+        if (!shaped.detectedValidation) {
+            shaped.detectedValidation = detected;
+        }
+
+        shaped.validationType = normalizedValidation;
 
         return shaped;
     }
@@ -128,18 +511,7 @@ document.addEventListener("DOMContentLoaded", () => {
         button.title = log.bookmarked ? "Remove bookmark" : "Bookmark event";
         button.textContent = log.bookmarked ? "★" : "☆";
 
-        button.addEventListener("click", () => {
-            if (log.bookmarked) {
-                log.bookmarked = false;
-                log.comment = "";
-            } else {
-                const comment = prompt("Add a comment for this bookmark:", log.comment || "");
-                log.bookmarked = true;
-                log.comment = comment || "";
-            }
-            saveLogs();
-            updateDisplays(logs);
-        });
+        button.addEventListener("click", () => openBookmarkModal(log));
 
         return button;
     }
@@ -167,6 +539,9 @@ document.addEventListener("DOMContentLoaded", () => {
         const timestampCell = document.createElement("td");
         timestampCell.textContent = log.timestamp || "—";
 
+        const validationCell = document.createElement("td");
+        validationCell.textContent = resolveValidationValue(log) || "—";
+
         const siteCell = document.createElement("td");
         siteCell.textContent = (log.siteName || "—").trim();
 
@@ -185,6 +560,7 @@ document.addEventListener("DOMContentLoaded", () => {
         row.appendChild(eventCell);
         row.appendChild(truckCell);
         row.appendChild(timestampCell);
+        row.appendChild(validationCell);
         row.appendChild(siteCell);
         row.appendChild(pageCell);
         row.appendChild(commentCell);
@@ -216,6 +592,10 @@ document.addEventListener("DOMContentLoaded", () => {
             ? `<a href="${log.pageUrl}" target="_blank">${log.pageUrl}</a>`
             : "—";
 
+        const validationCell = document.createElement("td");
+        const validationText = resolveValidationValue(log);
+        validationCell.textContent = validationText || "—";
+
         const callsCell = document.createElement("td");
         const attempts = Array.isArray(log.callHistory) ? log.callHistory.length : 0;
         callsCell.innerHTML = attempts
@@ -234,6 +614,7 @@ document.addEventListener("DOMContentLoaded", () => {
         row.appendChild(timestampCell);
         row.appendChild(siteCell);
         row.appendChild(pageCell);
+        row.appendChild(validationCell);
         row.appendChild(callsCell);
         row.appendChild(actionsCell);
 
@@ -255,6 +636,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 log.pageUrl,
                 log.siteName,
                 log.eventId,
+                resolveValidationValue(log),
             ]
                 .filter(Boolean)
                 .join(" ")
@@ -294,8 +676,22 @@ document.addEventListener("DOMContentLoaded", () => {
         validationError.classList.add("hidden");
         validationEditGroup.classList.add("hidden");
         validationInput.value = "";
+        validationDisplay.textContent = "";
+        validationDisplay.className = "tag";
         callSummaryLeft.innerHTML = "";
         callSummaryRight.innerHTML = "";
+        setValidationButtonState(null);
+        saveCallButton.disabled = false;
+        if (copyEventTimeButton) {
+            copyEventTimeButton.textContent = "Only Copy Event Time";
+            copyEventTimeButton.disabled = false;
+        }
+        if (copyCallTimeButton) {
+            copyCallTimeButton.textContent = "Only Copy Call Time";
+            copyCallTimeButton.disabled = false;
+        }
+        copyTabOutputButton.textContent = "Copy to Clipboard";
+        copyTabOutputButton.disabled = false;
     }
 
     function closeCallModal() {
@@ -313,20 +709,26 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const attempts = Array.isArray(log.callHistory) ? log.callHistory.length : 0;
         const attemptNumber = attempts + 1;
-        const defaultValidation = (log.validationType || log.eventType || "").trim();
+        const detectedValidation = resolveValidationValue(log);
+        const defaultValidation = normalizeValidationType(detectedValidation);
 
         activeCallState = {
             logId,
             attemptNumber,
             defaultValidation,
-            finalValidation: defaultValidation,
+            finalValidation: defaultValidation || detectedValidation || "",
             validationConfirmed: false,
             contactSelection: null,
             monitorName: "",
+            detectedValidation,
+            eventTimeParts: null,
+            callTimeParts: null,
+            latestAttemptIndex: null,
         };
 
-        validationDisplay.textContent = defaultValidation || "—";
+        validationDisplay.textContent = defaultValidation || detectedValidation || "—";
         validationDisplay.className = "tag";
+        setValidationButtonState(null);
 
         callSummaryLeft.innerHTML = `
             <strong>Event Type</strong>
@@ -342,6 +744,8 @@ document.addEventListener("DOMContentLoaded", () => {
             <span>${(log.siteName || "—").trim()}</span>
             <strong>Attempts Logged</strong>
             <span>${attempts}</span>
+            <strong>Validation Type</strong>
+            <span>${defaultValidation || detectedValidation || "—"}</span>
             <strong>Page</strong>
             <span>${log.pageUrl ? `<a href="${log.pageUrl}" target="_blank">${log.pageUrl}</a>` : "—"}</span>
         `;
@@ -376,33 +780,29 @@ document.addEventListener("DOMContentLoaded", () => {
     function generateTabDelimitedRow(log, attemptRecord, monitorName) {
         const now = attemptRecord ? new Date(attemptRecord.timestamp) : new Date();
         const dateStr = formatDate(now);
-        const eventCreatedAt = log.createdAt ? new Date(log.createdAt) : now;
-
-        const attempts = Array.isArray(log.callHistory) ? log.callHistory : [];
-        const attemptTimes = [attempts[0], attempts[1], attempts[2]].map((entry) =>
-            entry ? formatTime(new Date(entry.timestamp)) : "",
-        );
-
-        const callLabels = [
-            attempts[0] ? "Call Attempt 1" : "",
-            attempts[1] ? "Call Attempt 2" : "",
-            attempts[2] ? "Call Attempt 3" : "",
-        ];
+        const eventTime = getEventTimeParts(log);
+        const callTimes = getCallTimeParts(log.callHistory);
 
         const contactMade = attemptRecord ? attemptRecord.contactMade : false;
         const receptor = contactMade ? "Dispatch" : "";
-        const validationType = (log.validationType || log.eventType || "").trim();
+        const baseValidation =
+            (attemptRecord && attemptRecord.validationType) ||
+            (activeCallState?.finalValidation && activeCallState.finalValidation.trim()) ||
+            (activeCallState?.defaultValidation && activeCallState.defaultValidation.trim()) ||
+            resolveValidationValue(log);
 
-        return [
+        const validationType = normalizeValidationType(baseValidation) || baseValidation || "";
+
+        const row = [
             dateStr,
-            log.eventId || "",
-            formatTime(eventCreatedAt),
-            attemptTimes[0],
-            callLabels[0],
-            attemptTimes[1],
-            callLabels[1],
-            attemptTimes[2],
-            callLabels[2],
+            eventTime.hour,
+            eventTime.minute,
+            callTimes[0].hour,
+            callTimes[0].minute,
+            callTimes[1].hour,
+            callTimes[1].minute,
+            callTimes[2].hour,
+            callTimes[2].minute,
             (log.siteName || "").trim(),
             log.truckNumber || "",
             validationType,
@@ -410,6 +810,8 @@ document.addEventListener("DOMContentLoaded", () => {
             contactMade ? "Yes" : "No",
             receptor,
         ].join("\t");
+
+        return { row, eventTime, callTimes };
     }
 
     function handleSaveCall() {
@@ -447,7 +849,18 @@ document.addEventListener("DOMContentLoaded", () => {
         const contactMade = activeCallState.contactSelection === "yes";
         const timestamp = new Date().toISOString();
 
-        log.validationType = activeCallState.finalValidation || log.validationType || log.eventType;
+        const fallbackValidation =
+            (activeCallState.finalValidation && activeCallState.finalValidation.trim()) ||
+            (activeCallState.defaultValidation && activeCallState.defaultValidation.trim()) ||
+            resolveValidationValue(log);
+        const normalizedFinalValidation = normalizeValidationType(fallbackValidation);
+        const finalValidationValue = normalizedFinalValidation || fallbackValidation || "";
+
+        activeCallState.finalValidation = finalValidationValue;
+        log.validationType = finalValidationValue;
+        log.validationTypeRaw = finalValidationValue;
+        log.validationTypeDetected = finalValidationValue;
+        log.detectedValidation = finalValidationValue;
         log.monitorName = monitorName;
         log.callHistory = Array.isArray(log.callHistory) ? log.callHistory : [];
 
@@ -456,11 +869,16 @@ document.addEventListener("DOMContentLoaded", () => {
             timestamp,
             contactMade,
             receptor: contactMade ? "Dispatch" : "",
+            validationType: finalValidationValue,
         };
 
         log.callHistory.push(attemptRecord);
 
-        const tabRow = generateTabDelimitedRow(log, attemptRecord, monitorName);
+        const { row: tabRow, eventTime, callTimes } = generateTabDelimitedRow(
+            log,
+            attemptRecord,
+            monitorName,
+        );
         attemptRecord.tabRow = tabRow;
 
         chrome.storage.sync.set({ monitorName });
@@ -470,6 +888,12 @@ document.addEventListener("DOMContentLoaded", () => {
         tabOutput.value = tabRow;
         callResultBox.classList.remove("hidden");
         saveCallButton.disabled = true;
+        activeCallState.eventTimeParts = eventTime;
+        activeCallState.callTimeParts = callTimes;
+        activeCallState.latestAttemptIndex = Math.min(
+            callTimes.length - 1,
+            Math.max(0, attemptRecord.attempt - 1),
+        );
     }
 
     filterInput.addEventListener("input", () => updateDisplays(logs));
@@ -479,11 +903,12 @@ document.addEventListener("DOMContentLoaded", () => {
             return;
         }
 
-        if (confirm("Are you sure you want to clear all logs?")) {
+        openConfirmModal("Clear all saved events?", () => {
             logs = [];
             saveLogs();
             updateDisplays(logs);
-        }
+            showToast("Event log cleared");
+        });
     });
 
     exportCSVButton.addEventListener("click", () => {
@@ -509,19 +934,19 @@ document.addEventListener("DOMContentLoaded", () => {
             const attempts = Array.isArray(log.callHistory) ? log.callHistory.length : 0;
             const lastAttempt = attempts ? log.callHistory[attempts - 1] : null;
 
-            return [
-                log.eventId || "",
-                log.eventType || "",
-                log.truckNumber || "",
-                log.timestamp || "",
-                (log.siteName || "").trim(),
-                log.pageUrl || "",
-                attempts,
-                log.validationType || log.eventType || "",
-                log.monitorName || "",
-                lastAttempt ? (lastAttempt.contactMade ? "Contacted" : "No Contact") : "",
-                lastAttempt && lastAttempt.tabRow ? lastAttempt.tabRow.replace(/\t/g, " ") : "",
-            ]
+                return [
+                    log.eventId || "",
+                    log.eventType || "",
+                    log.truckNumber || "",
+                    log.timestamp || "",
+                    (log.siteName || "").trim(),
+                    log.pageUrl || "",
+                    attempts,
+                    resolveValidationValue(log),
+                    log.monitorName || "",
+                    lastAttempt ? (lastAttempt.contactMade ? "Contacted" : "No Contact") : "",
+                    lastAttempt && lastAttempt.tabRow ? lastAttempt.tabRow.replace(/\t/g, " ") : "",
+                ]
                 .map((value) => `"${(value || "").replace(/"/g, '""')}"`)
                 .join(",");
         });
@@ -543,7 +968,10 @@ document.addEventListener("DOMContentLoaded", () => {
         if (!activeCallState) {
             return;
         }
-        activeCallState.finalValidation = activeCallState.defaultValidation;
+        const normalized = normalizeValidationType(activeCallState.defaultValidation);
+        activeCallState.finalValidation = normalized;
+        validationDisplay.textContent = normalized || "—";
+        setValidationButtonState("yes");
         setValidationConfirmed(true);
         validationEditGroup.classList.add("hidden");
     });
@@ -552,8 +980,13 @@ document.addEventListener("DOMContentLoaded", () => {
         if (!activeCallState) {
             return;
         }
+        setValidationButtonState("no");
+        setValidationConfirmed(false);
         validationEditGroup.classList.remove("hidden");
-        validationInput.value = activeCallState.finalValidation || activeCallState.defaultValidation;
+        validationInput.value =
+            activeCallState.finalValidation ||
+            activeCallState.detectedValidation ||
+            activeCallState.defaultValidation;
         validationInput.focus();
     });
 
@@ -566,8 +999,10 @@ document.addEventListener("DOMContentLoaded", () => {
             validationInput.focus();
             return;
         }
-        activeCallState.finalValidation = updated;
-        validationDisplay.textContent = updated;
+        const normalized = normalizeValidationType(updated) || updated;
+        activeCallState.finalValidation = normalized;
+        validationDisplay.textContent = normalized || "—";
+        setValidationButtonState("yes");
         validationEditGroup.classList.add("hidden");
         setValidationConfirmed(true);
     });
@@ -576,6 +1011,9 @@ document.addEventListener("DOMContentLoaded", () => {
         validationEditGroup.classList.add("hidden");
         if (activeCallState) {
             activeCallState.finalValidation = activeCallState.defaultValidation;
+            validationDisplay.textContent = activeCallState.defaultValidation || "—";
+            setValidationButtonState(null);
+            setValidationConfirmed(false);
         }
     });
 
@@ -590,16 +1028,189 @@ document.addEventListener("DOMContentLoaded", () => {
             return;
         }
         navigator.clipboard.writeText(text).then(() => {
-            copyTabOutputButton.textContent = "Copied!";
-            setTimeout(() => {
-                copyTabOutputButton.textContent = "Copy to Clipboard";
-            }, 1500);
+            flashButtonFeedback(copyTabOutputButton, "Copied!", 1500);
         });
     });
 
+    if (copyEventTimeButton) {
+        copyEventTimeButton.addEventListener("click", () => {
+            if (!activeCallState || !activeCallState.eventTimeParts) {
+                return;
+            }
+            const { hour = "", minute = "" } = activeCallState.eventTimeParts;
+            if (!hour && !minute) {
+                return;
+            }
+            navigator.clipboard
+                .writeText(`${hour}\t${minute}`)
+                .then(() => flashButtonFeedback(copyEventTimeButton, "Copied!"));
+        });
+    }
+
+    if (copyCallTimeButton) {
+        copyCallTimeButton.addEventListener("click", () => {
+            if (
+                !activeCallState ||
+                !Array.isArray(activeCallState.callTimeParts) ||
+                activeCallState.latestAttemptIndex == null
+            ) {
+                return;
+            }
+
+            const index = activeCallState.latestAttemptIndex;
+            if (index < 0 || index >= activeCallState.callTimeParts.length) {
+                return;
+            }
+
+            const parts = activeCallState.callTimeParts[index] || { hour: "", minute: "" };
+            if (!parts.hour && !parts.minute) {
+                return;
+            }
+
+            navigator.clipboard
+                .writeText(`${parts.hour}\t${parts.minute}`)
+                .then(() => flashButtonFeedback(copyCallTimeButton, "Copied!"));
+        });
+    }
+
+    if (bookmarkSaveButton) {
+        bookmarkSaveButton.addEventListener("click", () => {
+            if (!activeBookmarkId) {
+                closeBookmarkModal();
+                return;
+            }
+
+            const log = getLogById(activeBookmarkId);
+            if (!log) {
+                closeBookmarkModal();
+                return;
+            }
+
+            const comment = bookmarkCommentInput ? bookmarkCommentInput.value.trim() : "";
+            const wasBookmarked = log.bookmarked;
+            log.bookmarked = true;
+            log.comment = comment;
+            saveLogs();
+            updateDisplays(logs);
+            showToast(wasBookmarked ? "Bookmark updated" : "Bookmark added");
+            closeBookmarkModal();
+        });
+    }
+
+    if (bookmarkRemoveButton) {
+        bookmarkRemoveButton.addEventListener("click", () => {
+            if (!activeBookmarkId) {
+                closeBookmarkModal();
+                return;
+            }
+
+            const log = getLogById(activeBookmarkId);
+            if (!log) {
+                closeBookmarkModal();
+                return;
+            }
+
+            openConfirmModal("Remove this bookmark?", () => {
+                log.bookmarked = false;
+                log.comment = "";
+                saveLogs();
+                updateDisplays(logs);
+                showToast("Bookmark removed");
+                closeBookmarkModal();
+            });
+        });
+    }
+
+    if (bookmarkCancelButton) {
+        bookmarkCancelButton.addEventListener("click", () => {
+            closeBookmarkModal();
+        });
+    }
+
+    if (closeBookmarkModalButton) {
+        closeBookmarkModalButton.addEventListener("click", () => {
+            closeBookmarkModal();
+        });
+    }
+
+    if (bookmarkModal) {
+        bookmarkModal.addEventListener("click", (event) => {
+            if (event.target === bookmarkModal) {
+                closeBookmarkModal();
+            }
+        });
+    }
+
+    if (confirmAcceptButton) {
+        confirmAcceptButton.addEventListener("click", () => {
+            const action = confirmAction;
+            closeConfirmModal();
+            if (typeof action === "function") {
+                action();
+            }
+        });
+    }
+
+    if (confirmCancelButton) {
+        confirmCancelButton.addEventListener("click", () => {
+            closeConfirmModal();
+        });
+    }
+
+    if (closeConfirmButton) {
+        closeConfirmButton.addEventListener("click", () => {
+            closeConfirmModal();
+        });
+    }
+
+    if (confirmModal) {
+        confirmModal.addEventListener("click", (event) => {
+            if (event.target === confirmModal) {
+                closeConfirmModal();
+            }
+        });
+    }
+
     window.addEventListener("keydown", (event) => {
-        if (event.key === "Escape" && callModal.classList.contains("show")) {
+        if (event.key !== "Escape") {
+            return;
+        }
+
+        if (bookmarkModal && bookmarkModal.classList.contains("show")) {
+            closeBookmarkModal();
+            return;
+        }
+
+        if (confirmModal && confirmModal.classList.contains("show")) {
+            closeConfirmModal();
+            return;
+        }
+
+        if (callModal.classList.contains("show")) {
             closeCallModal();
+        }
+    });
+
+    chrome.storage.sync.get(
+        { validationVocabulary: DEFAULT_VALIDATION_VOCABULARY, validationFilterEnabled: true },
+        (data) => {
+            refreshValidationPreferences(data.validationVocabulary, data.validationFilterEnabled);
+        },
+    );
+
+    chrome.storage.onChanged.addListener((changes, areaName) => {
+        if (areaName !== "sync") {
+            return;
+        }
+
+        const vocabChange = changes.validationVocabulary;
+        const filterChange = changes.validationFilterEnabled;
+
+        if (vocabChange || filterChange) {
+            refreshValidationPreferences(
+                vocabChange ? vocabChange.newValue : validationVocabulary,
+                filterChange ? filterChange.newValue : validationFilterEnabled,
+            );
         }
     });
 
@@ -608,5 +1219,6 @@ document.addEventListener("DOMContentLoaded", () => {
         logs = deduplicateLogs(loadedLogs);
         saveLogs();
         updateDisplays(logs);
+        refreshValidationPreferences(validationVocabulary, validationFilterEnabled);
     });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -25,5 +25,5 @@
         "default_popup": "popup.html",
         "default_icon": "icon.png"
     },
-    "options_page": "log.html"
+    "options_page": "settings.html"
 }

--- a/popup.html
+++ b/popup.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Project Time Weaver</title>
+    <title>QA Assist</title>
     <style>
         :root {
             color-scheme: dark;
@@ -28,11 +28,6 @@
             font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
             background: radial-gradient(circle at top, rgba(76, 141, 255, 0.18), transparent 55%), var(--bg-color);
             color: var(--text-primary);
-        }
-
-        h1 {
-            font-size: 18px;
-            margin: 0;
         }
 
         h2 {
@@ -62,6 +57,18 @@
             background: linear-gradient(135deg, rgba(76, 141, 255, 0.35), rgba(17, 20, 26, 0.85));
             border: 1px solid rgba(76, 141, 255, 0.35);
             box-shadow: 0 12px 22px rgba(0, 0, 0, 0.35);
+        }
+
+        .header-identity {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .status-icon {
+            width: 64px;
+            height: auto;
+            display: block;
         }
 
         .header small {
@@ -326,8 +333,8 @@
 <body>
     <div class="container">
         <div class="header">
-            <div>
-                <h1>Project Time Weaver</h1>
+            <div class="header-identity">
+                <img id="statusIcon" class="status-icon" src="off.png" alt="QA Assist status icon">
                 <small>QA Assist Control Center</small>
             </div>
             <div class="status-pill" id="statusPill">
@@ -404,6 +411,7 @@
                 <button id="viewLogs">Open Event Log</button>
                 <button id="openOverrides" class="secondary">Site Overrides</button>
                 <button id="openSiteInfo" class="secondary">Site Info</button>
+                <button id="openSettings" class="secondary">Settings</button>
             </div>
         </section>
     </div>

--- a/popup.js
+++ b/popup.js
@@ -6,6 +6,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const statusDot = document.getElementById("statusDot");
     const scanningBadge = document.getElementById("scanningBadge");
     const scanIndicator = document.getElementById("scanIndicator");
+    const statusIcon = document.getElementById("statusIcon");
     const autoPressNextToggle = document.getElementById("autoPressNext");
     const removeEyeTrackerToggle = document.getElementById("removeEyeTracker");
     const monitorNameInput = document.getElementById("monitorName");
@@ -13,6 +14,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const openOverridesButton = document.getElementById("openOverrides");
     const openSiteInfoButton = document.getElementById("openSiteInfo");
     const overrideBadge = document.getElementById("overrideBadge");
+    const openSettingsButton = document.getElementById("openSettings");
 
     const scanConfirmModal = document.getElementById("scanConfirm");
     const confirmScanButton = document.getElementById("confirmScan");
@@ -82,6 +84,12 @@ document.addEventListener("DOMContentLoaded", () => {
             ? "Scanning mode is actively monitoring for new events."
             : "Scanning mode is currently inactive.";
         scanIndicator.classList.toggle("active", isEnabled);
+
+        if (statusIcon) {
+            const iconPath = isEnabled ? "on.png" : "off.png";
+            statusIcon.src = chrome.runtime.getURL(iconPath);
+            statusIcon.alt = `QA Assist ${isEnabled ? "enabled" : "disabled"} status icon`;
+        }
     }
 
     function sendMessageToActiveTab(payload) {
@@ -200,5 +208,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
     openSiteInfoButton.addEventListener("click", () => {
         chrome.tabs.create({ url: chrome.runtime.getURL("site-info.html") });
+    });
+
+    openSettingsButton.addEventListener("click", () => {
+        chrome.tabs.create({ url: chrome.runtime.getURL("settings.html") });
     });
 });

--- a/settings.html
+++ b/settings.html
@@ -1,147 +1,579 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <title>Settings</title>
+    <meta charset="UTF-8">
+    <title>QA Assist · Settings</title>
     <style>
+        :root {
+            color-scheme: dark;
+            --bg: #0d1119;
+            --panel: #161c2a;
+            --card: #1d2435;
+            --border: #252f45;
+            --text: #f5f7ff;
+            --muted: #9ba4c4;
+            --accent: #4c8dff;
+            --accent-soft: rgba(76, 141, 255, 0.22);
+            --danger: #ff5c8d;
+            --success: #3dd68c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
         body {
-            font-family: Arial, sans-serif;
-            background-color: #222;
-            color: #fff;
-            padding: 20px;
+            margin: 0;
+            padding: 40px 44px 52px;
+            font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+            background: radial-gradient(circle at top, rgba(76, 141, 255, 0.14), transparent 55%), var(--bg);
+            color: var(--text);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
-        h2 {
-            margin-top: 0;
+
+        .top-nav {
+            position: fixed;
+            top: 24px;
+            left: 50%;
+            transform: translateX(-50%);
+            display: inline-flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            padding: 8px 12px;
+            border-radius: 999px;
+            background: rgba(13, 17, 25, 0.78);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            z-index: 10;
         }
+
+        .top-nav a {
+            padding: 6px 14px;
+            border-radius: 999px;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            background: rgba(255, 255, 255, 0.06);
+            color: var(--text);
+            text-decoration: none;
+            font-size: 13px;
+            font-weight: 600;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        .top-nav a:hover,
+        .top-nav a:focus {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+            outline: none;
+        }
+
+        .toast {
+            position: fixed;
+            bottom: 28px;
+            left: 50%;
+            transform: translateX(-50%) translateY(140%);
+            background: rgba(18, 24, 36, 0.96);
+            color: var(--text);
+            padding: 12px 22px;
+            border-radius: 999px;
+            border: 1px solid rgba(76, 141, 255, 0.4);
+            box-shadow: 0 18px 42px rgba(0, 0, 0, 0.45);
+            opacity: 0;
+            transition: opacity 0.25s ease, transform 0.25s ease;
+            font-weight: 600;
+            pointer-events: none;
+            z-index: 20;
+        }
+
+        .toast.show {
+            opacity: 1;
+            transform: translateX(-50%) translateY(0);
+        }
+
+        .panel {
+            width: min(960px, 100%);
+            background: var(--panel);
+            border-radius: 26px;
+            border: 1px solid var(--border);
+            padding: 36px;
+            box-shadow: 0 48px 96px rgba(0, 0, 0, 0.35);
+            margin-top: 96px;
+        }
+
+        .panel-header {
+            margin-bottom: 28px;
+        }
+
+        .panel-header h1 {
+            margin: 0;
+            font-size: 30px;
+            letter-spacing: 0.02em;
+        }
+
+        .panel-header p {
+            margin: 10px 0 0;
+            color: var(--muted);
+            max-width: 720px;
+        }
+
+        .settings-section {
+            background: var(--card);
+            border-radius: 20px;
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            padding: 24px;
+            margin-bottom: 24px;
+        }
+
+        .settings-section:last-of-type {
+            margin-bottom: 32px;
+        }
+
+        .section-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+            margin-bottom: 16px;
+        }
+
+        .section-header h2 {
+            margin: 0;
+            font-size: 20px;
+        }
+
+        .section-header p {
+            margin: 0;
+            color: var(--muted);
+            font-size: 13px;
+        }
+
+        .helper {
+            margin: 0 0 16px;
+            color: var(--muted);
+            font-size: 13px;
+        }
+
+        label {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 12px;
+            font-size: 14px;
+            color: var(--text);
+        }
+
+        label span {
+            color: inherit;
+        }
+
+        input[type="text"],
+        input[type="number"],
+        select {
+            background: rgba(9, 13, 22, 0.82);
+            color: var(--text);
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            border-radius: 10px;
+            padding: 8px 10px;
+            font-size: 13px;
+        }
+
+        input[type="number"] {
+            width: 72px;
+        }
+
+        .stack {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
         .rule {
             display: flex;
-            gap: 10px;
-            margin-bottom: 10px;
+            gap: 12px;
+            align-items: center;
         }
+
+        .rule select {
+            flex: 1;
+        }
+
         .site-rule {
-            border: 1px solid #555;
-            padding: 10px;
-            margin-bottom: 10px;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 16px;
+            padding: 16px;
+            margin-bottom: 12px;
+            background: rgba(10, 14, 24, 0.82);
+            display: grid;
+            gap: 10px;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
         }
+
         .site-rule label {
-            display: block;
-            margin-top: 5px;
+            margin: 0;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 6px;
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--muted);
         }
-        select {
-            background-color: #333;
-            color: #fff;
-            border: 1px solid #555;
-            padding: 5px;
-            border-radius: 5px;
+
+        .site-rule label span,
+        .site-rule label input,
+        .site-rule label select {
+            font-size: 13px;
+            text-transform: none;
+            letter-spacing: normal;
+            color: var(--text);
         }
+
+        .toggle-row {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            font-weight: 600;
+            margin-bottom: 16px;
+        }
+
+        .inline-toggle {
+            margin-bottom: 0;
+        }
+
+        .inline-input {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 13px;
+            color: var(--muted);
+        }
+
         button {
-            padding: 5px 10px;
-            border: none;
-            border-radius: 5px;
+            padding: 8px 14px;
+            border-radius: 10px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: rgba(255, 255, 255, 0.06);
+            color: var(--text);
             cursor: pointer;
+            font-weight: 600;
+            transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
         }
-        #addRule {
-            background-color: #28a745;
-            color: #fff;
+
+        button:hover,
+        button:focus {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+            outline: none;
         }
-        .remove {
-            background-color: #dc3545;
-            color: #fff;
-        }
-        input[type="number"] {
-            background-color: #333;
-            color: #fff;
-            border: 1px solid #555;
-            padding: 5px;
-            border-radius: 5px;
-            width: 60px;
-        }
-        input[type="text"] {
-            background-color: #333;
-            color: #fff;
-            border: 1px solid #555;
-            padding: 5px;
-            border-radius: 5px;
-        }
+
+        #addRule,
         #addSiteRule {
-            background-color: #28a745;
+            background: linear-gradient(135deg, var(--accent), #6aa2ff);
+            border-color: transparent;
             color: #fff;
         }
+
+        #addValidationTerm {
+            background: rgba(76, 141, 255, 0.12);
+            border-color: rgba(76, 141, 255, 0.32);
+            color: var(--accent);
+        }
+
+        .icon-button {
+            width: 36px;
+            height: 36px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 18px;
+        }
+
+        .remove {
+            background: rgba(255, 92, 141, 0.18);
+            border-color: rgba(255, 92, 141, 0.35);
+            color: var(--danger);
+        }
+
         .disabled {
-            opacity: 0.5;
-            pointer-events: none;
+            opacity: 0.55;
         }
+
+        .validation-helper {
+            margin: 0 0 12px;
+            color: var(--muted);
+            font-size: 13px;
+        }
+
+        .validation-list {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .validation-row {
+            display: grid;
+            grid-template-columns: minmax(180px, 2fr) minmax(220px, 3fr) auto;
+            gap: 12px;
+            align-items: center;
+            padding: 16px;
+            border-radius: 16px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            background: rgba(10, 14, 24, 0.82);
+        }
+
+        .validation-row label {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            margin: 0;
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--muted);
+        }
+
+        .validation-row input[type="text"] {
+            width: 100%;
+        }
+
+        .validation-disabled {
+            opacity: 0.6;
+        }
+
+        .modal-backdrop {
+            position: fixed;
+            inset: 0;
+            background: rgba(6, 10, 18, 0.72);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: 30;
+        }
+
+        .modal-backdrop.show {
+            display: flex;
+        }
+
+        .modal-card {
+            position: relative;
+            width: min(420px, 90vw);
+            background: rgba(18, 24, 36, 0.96);
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            border-radius: 20px;
+            padding: 26px 28px 24px;
+            box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45);
+            color: var(--text);
+        }
+
+        .modal-card h3 {
+            margin: 0 0 10px;
+            font-size: 20px;
+        }
+
+        .modal-card p {
+            margin: 0 0 20px;
+            color: var(--muted);
+            font-size: 14px;
+        }
+
+        .modal-actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 12px;
+        }
+
+        .modal-card .danger {
+            background: rgba(255, 92, 141, 0.2);
+            border-color: rgba(255, 92, 141, 0.45);
+            color: var(--danger);
+        }
+
+        .modal-close {
+            position: absolute;
+            top: 12px;
+            right: 14px;
+            width: 32px;
+            height: 32px;
+            border-radius: 50%;
+            border: 1px solid rgba(255, 255, 255, 0.14);
+            background: rgba(255, 255, 255, 0.04);
+            color: var(--muted);
+            font-size: 18px;
+            line-height: 1;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+        }
+
         #saveSettings {
-            background-color: #007bff;
+            background: linear-gradient(135deg, var(--accent), #6aa2ff);
+            border-color: transparent;
             color: #fff;
-            margin-top: 10px;
+            padding: 12px 22px;
+            font-size: 15px;
+            border-radius: 14px;
+        }
+
+        .footer-note {
+            color: var(--muted);
+            font-size: 12px;
+            margin-top: 8px;
+        }
+
+        @media (max-width: 960px) {
+            body {
+                padding: 32px 20px 40px;
+            }
+
+            .top-nav {
+                position: static;
+                transform: none;
+                margin-bottom: 20px;
+            }
+
+            .panel {
+                margin-top: 0;
+            }
         }
     </style>
 </head>
 <body>
-    <h2>Settings</h2>
-    <h3>Custom Speed</h3>
-    <div id="rulesContainer"></div>
-    <button id="addRule">+</button>
-    <br>
-    <h3>Smart Skip</h3>
-    <label>
-        <input id="smartSkipToggle" type="checkbox"> Enable Smart Skip
-    </label>
-    <br>
-    <h3>Looping Mode</h3>
-    <label>
-        <input id="loopToggle" type="checkbox"> Looping Mode
-    </label>
-    <br>
-    <label id="loopResetContainer">
-        Seconds till "reset" <input id="loopReset" type="number" min="0" value="10">
-    </label>
-    <br>
-    <label id="loopHoldContainer">
-        Seconds held <input id="loopHold" type="number" min="0" value="5">
-    </label>
-    <br>
-    <label id="loopFollowContainer">
-        <input id="loopFollow" type="checkbox"> Follow up
-    </label>
-    <br>
-    <label id="skipContainer">
-        If No Video Playback is detected then skip after
-        <input id="skipDelay" type="number" min="0" max="30" value="0"> seconds
-    </label>
-    <br>
-    <h3>Simple Auto Skip</h3>
-    <label>
-        <input id="simpleSkipToggle" type="checkbox"> Enable Simple Auto Skip
-    </label>
-    <br>
-    <label id="simpleSkipDelayContainer">
-        Skip after <input id="simpleSkipDelay" type="number" min="0" value="5"> seconds
-    </label>
-    <br>
-    <h3>Site Overrides</h3>
-    <div id="siteRulesContainer"></div>
-    <button id="addSiteRule">+</button>
-    <br>
-    <h3>Buffer Between Videos</h3>
-    <label>
-        Buffer <input id="keyDelay" type="number" min="0" value="2"> seconds between videos
-    </label>
-    <br>
-    <h3>Scanning Mode</h3>
-    <label>
-        <input id="scanToggle" type="checkbox"> Scanning Mode
-    </label>
-    <br>
-    <label id="scanHotkeyContainer">
-        Shortcut <input id="scanHotkey" type="text" value="Ctrl+Shift+K">
-    </label>
-    <br>
-    <label id="scanDurationContainer">
-        Duration <input id="scanDuration" type="number" min="1" value="60"> seconds
-    </label>
-    <br>
-    <button id="saveSettings">Save</button>
+    <nav class="top-nav" aria-label="QA Assist navigation">
+        <a href="log.html">Event Log</a>
+        <a href="settings.html">Settings</a>
+        <a href="site-overrides.html">Site Overrides</a>
+        <a href="site-info.html">Site Info</a>
+    </nav>
+
+    <main class="panel">
+        <header class="panel-header">
+            <h1>QA Assist Settings</h1>
+            <p>Configure automation, playback, and scanning preferences. Changes are saved to sync storage so they travel with your QA Assist profile.</p>
+        </header>
+
+        <section class="settings-section">
+            <div class="section-header">
+                <h2>Custom Speed</h2>
+                <button id="addRule" class="icon-button" type="button" aria-label="Add custom speed rule">+</button>
+            </div>
+            <p class="helper">Map event types to preferred playback speeds for consistent review tempo.</p>
+            <div id="rulesContainer" class="stack"></div>
+        </section>
+
+        <section class="settings-section">
+            <div class="section-header">
+                <h2>Smart Skip</h2>
+            </div>
+            <label class="toggle-row">
+                <input id="smartSkipToggle" type="checkbox"> <span>Enable Smart Skip</span>
+            </label>
+            <label id="skipContainer" class="inline-input">
+                Skip when playback stalls after
+                <input id="skipDelay" type="number" min="0" max="30" value="0"> seconds
+            </label>
+        </section>
+
+        <section class="settings-section">
+            <div class="section-header">
+                <h2>Looping Mode</h2>
+            </div>
+            <label class="toggle-row">
+                <input id="loopToggle" type="checkbox"> <span>Looping Mode</span>
+            </label>
+            <div class="stack">
+                <label id="loopResetContainer" class="inline-input">
+                    Seconds till "reset"
+                    <input id="loopReset" type="number" min="0" value="10">
+                </label>
+                <label id="loopHoldContainer" class="inline-input">
+                    Seconds held
+                    <input id="loopHold" type="number" min="0" value="5">
+                </label>
+                <label id="loopFollowContainer" class="toggle-row">
+                    <input id="loopFollow" type="checkbox"> <span>Follow up</span>
+                </label>
+            </div>
+        </section>
+
+        <section class="settings-section">
+            <div class="section-header">
+                <h2>Simple Auto Skip</h2>
+            </div>
+            <label class="toggle-row">
+                <input id="simpleSkipToggle" type="checkbox"> <span>Enable Simple Auto Skip</span>
+            </label>
+            <label id="simpleSkipDelayContainer" class="inline-input">
+                Skip after
+                <input id="simpleSkipDelay" type="number" min="0" value="5"> seconds
+            </label>
+        </section>
+
+        <section class="settings-section">
+            <div class="section-header">
+                <h2>Validation Filter</h2>
+                <label class="toggle-row inline-toggle">
+                    <input id="validationFilterToggle" type="checkbox"> <span>Enable Filter</span>
+                </label>
+            </div>
+            <p class="validation-helper">Control which validation labels are auto-detected during call validation. When disabled, the original validation text is used.</p>
+            <div id="validationList" class="validation-list"></div>
+            <button id="addValidationTerm" type="button">Add validation label</button>
+        </section>
+
+        <section class="settings-section">
+            <div class="section-header">
+                <h2>Buffer Between Videos</h2>
+            </div>
+            <label class="inline-input">
+                Buffer
+                <input id="keyDelay" type="number" min="0" value="2"> seconds between videos
+            </label>
+        </section>
+
+        <section class="settings-section">
+            <div class="section-header">
+                <h2>Site Overrides</h2>
+                <button id="addSiteRule" class="icon-button" type="button" aria-label="Add site override">+</button>
+            </div>
+            <p class="helper">Create domain-specific automation profiles. Overrides apply automatically when the active tab matches the configured pattern.</p>
+            <div id="siteRulesContainer" class="stack"></div>
+        </section>
+
+        <section class="settings-section">
+            <div class="section-header">
+                <h2>Scanning Mode</h2>
+            </div>
+            <label class="toggle-row">
+                <input id="scanToggle" type="checkbox"> <span>Enable Scanning Mode</span>
+            </label>
+            <label id="scanHotkeyContainer" class="inline-input">
+                Shortcut
+                <input id="scanHotkey" type="text" value="Ctrl+Shift+K">
+            </label>
+            <label id="scanDurationContainer" class="inline-input">
+                Duration
+                <input id="scanDuration" type="number" min="1" value="60"> seconds
+            </label>
+        </section>
+
+        <button id="saveSettings" type="button">Save Settings</button>
+        <p class="footer-note">Settings take effect immediately on the active tab when saved.</p>
+    </main>
+
+    <div class="toast" id="settingsToast" role="status" aria-live="polite"></div>
+
+    <div class="modal-backdrop" id="confirmModal" aria-hidden="true">
+        <div class="modal-card" role="dialog" aria-modal="true" aria-labelledby="confirmTitle" aria-describedby="confirmMessage">
+            <button class="modal-close" id="confirmClose" type="button" aria-label="Close">×</button>
+            <h3 id="confirmTitle">Confirm action</h3>
+            <p id="confirmMessage">Are you sure you want to continue?</p>
+            <div class="modal-actions">
+                <button type="button" id="confirmCancel">Cancel</button>
+                <button type="button" id="confirmAccept" class="danger">Delete</button>
+            </div>
+        </div>
+    </div>
+
     <script src="settings.js"></script>
 </body>
 </html>

--- a/settings.js
+++ b/settings.js
@@ -8,6 +8,16 @@ const eventTypes = [
 ];
 const speeds = ['1', '1.25', '1.5', '2'];
 
+const DEFAULT_VALIDATION_VOCABULARY = [
+    { label: 'Blocked', keywords: ['blocked'] },
+    { label: 'Critical', keywords: ['critical'] },
+    { label: 'Moderate', keywords: ['moderate'] },
+    { label: '3 Low/hr', keywords: ['low'] },
+    { label: 'Cellphone', keywords: ['cell phone', 'cellphone', 'cell', 'phone'] },
+    { label: 'False Positive', keywords: ['false', 'non'] },
+    { label: 'Lost Connection', keywords: ['lost connection', 'lost', 'disconnect'] },
+];
+
 document.addEventListener('DOMContentLoaded', () => {
     const rulesContainer = document.getElementById('rulesContainer');
     const addRuleBtn = document.getElementById('addRule');
@@ -33,6 +43,193 @@ document.addEventListener('DOMContentLoaded', () => {
     const scanDurationInput = document.getElementById('scanDuration');
     const scanHotkeyContainer = document.getElementById('scanHotkeyContainer');
     const scanDurationContainer = document.getElementById('scanDurationContainer');
+    const toast = document.getElementById('settingsToast');
+    const validationListContainer = document.getElementById('validationList');
+    const addValidationTermButton = document.getElementById('addValidationTerm');
+    const validationFilterToggle = document.getElementById('validationFilterToggle');
+    const confirmModal = document.getElementById('confirmModal');
+    const confirmMessage = document.getElementById('confirmMessage');
+    const confirmAcceptButton = document.getElementById('confirmAccept');
+    const confirmCancelButton = document.getElementById('confirmCancel');
+    const confirmCloseButton = document.getElementById('confirmClose');
+
+    let toastTimeout = null;
+    let confirmResolver = null;
+
+    function showToast(message) {
+        if (!toast) {
+            return;
+        }
+
+        toast.textContent = message;
+        toast.classList.add('show');
+
+        if (toastTimeout) {
+            clearTimeout(toastTimeout);
+        }
+
+        toastTimeout = setTimeout(() => {
+            toast.classList.remove('show');
+        }, 2200);
+    }
+
+    function closeConfirmModal(result) {
+        if (!confirmModal) {
+            if (confirmResolver) {
+                confirmResolver(Boolean(result));
+                confirmResolver = null;
+            }
+            return;
+        }
+
+        confirmModal.classList.remove('show');
+
+        if (confirmResolver) {
+            confirmResolver(Boolean(result));
+            confirmResolver = null;
+        }
+    }
+
+    function requestConfirmation(message) {
+        if (!confirmModal || !confirmMessage) {
+            return Promise.resolve(true);
+        }
+
+        confirmMessage.textContent = message;
+        confirmModal.classList.add('show');
+
+        return new Promise((resolve) => {
+            confirmResolver = resolve;
+        });
+    }
+
+    if (confirmAcceptButton) {
+        confirmAcceptButton.addEventListener('click', () => closeConfirmModal(true));
+    }
+
+    if (confirmCancelButton) {
+        confirmCancelButton.addEventListener('click', () => closeConfirmModal(false));
+    }
+
+    if (confirmCloseButton) {
+        confirmCloseButton.addEventListener('click', () => closeConfirmModal(false));
+    }
+
+    if (confirmModal) {
+        confirmModal.addEventListener('click', (event) => {
+            if (event.target === confirmModal) {
+                closeConfirmModal(false);
+            }
+        });
+    }
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && confirmModal?.classList.contains('show')) {
+            closeConfirmModal(false);
+        }
+    });
+
+    function cloneDefaultVocabulary() {
+        return DEFAULT_VALIDATION_VOCABULARY.map((entry) => ({
+            label: entry.label,
+            keywords: Array.isArray(entry.keywords) ? [...entry.keywords] : [],
+        }));
+    }
+
+    function sanitizeVocabularyInput(input, { fallback = false } = {}) {
+        if (!Array.isArray(input)) {
+            return fallback ? cloneDefaultVocabulary() : [];
+        }
+
+        const seen = new Set();
+        const sanitized = input
+            .map((entry) => {
+                const label = String(entry?.label || '').trim();
+                if (!label) {
+                    return null;
+                }
+
+                const lowerLabel = label.toLowerCase();
+                if (seen.has(lowerLabel)) {
+                    return null;
+                }
+
+                const keywordSource = Array.isArray(entry?.keywords)
+                    ? entry.keywords
+                    : typeof entry?.keywords === 'string'
+                        ? entry.keywords.split(',')
+                        : [];
+
+                const keywords = Array.from(
+                    new Set(
+                        keywordSource
+                            .concat(label)
+                            .map((keyword) => String(keyword || '').trim())
+                            .filter(Boolean),
+                    ),
+                );
+
+                seen.add(lowerLabel);
+                return { label, keywords };
+            })
+            .filter(Boolean);
+
+        if (!sanitized.length && fallback) {
+            return cloneDefaultVocabulary();
+        }
+
+        return sanitized;
+    }
+
+    function createValidationRow(entry = {}) {
+        if (!validationListContainer) {
+            return null;
+        }
+
+        const row = document.createElement('div');
+        row.className = 'validation-row';
+
+        const labelField = document.createElement('label');
+        labelField.textContent = 'Label';
+        const labelInput = document.createElement('input');
+        labelInput.type = 'text';
+        labelInput.className = 'validation-label';
+        labelInput.value = entry.label || '';
+        labelField.appendChild(labelInput);
+
+        const keywordField = document.createElement('label');
+        keywordField.textContent = 'Keywords';
+        const keywordInput = document.createElement('input');
+        keywordInput.type = 'text';
+        keywordInput.className = 'validation-keywords';
+        keywordInput.placeholder = 'Comma separated matches';
+        keywordInput.value = Array.isArray(entry.keywords) ? entry.keywords.join(', ') : '';
+        keywordField.appendChild(keywordInput);
+
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.textContent = '×';
+        removeBtn.className = 'remove icon-button';
+        removeBtn.addEventListener('click', async () => {
+            const confirmed = await requestConfirmation('Remove this validation label?');
+            if (confirmed) {
+                row.remove();
+            }
+        });
+
+        row.append(labelField, keywordField, removeBtn);
+        validationListContainer.appendChild(row);
+
+        return labelInput;
+    }
+
+    function updateValidationEnabled() {
+        if (!validationListContainer || !validationFilterToggle) {
+            return;
+        }
+
+        validationListContainer.classList.toggle('validation-disabled', !validationFilterToggle.checked);
+    }
 
     function createSiteRuleRow(rule) {
         const div = document.createElement('div');
@@ -173,7 +370,12 @@ document.addEventListener('DOMContentLoaded', () => {
         const removeBtn = document.createElement('button');
         removeBtn.textContent = '-';
         removeBtn.className = 'remove';
-        removeBtn.addEventListener('click', () => div.remove());
+        removeBtn.addEventListener('click', async () => {
+            const confirmed = await requestConfirmation('Remove this site override?');
+            if (confirmed) {
+                div.remove();
+            }
+        });
 
         div.append(
             urlLabel,
@@ -264,7 +466,12 @@ document.addEventListener('DOMContentLoaded', () => {
         const removeBtn = document.createElement('button');
         removeBtn.textContent = '-';
         removeBtn.className = 'remove';
-        removeBtn.addEventListener('click', () => div.remove());
+        removeBtn.addEventListener('click', async () => {
+            const confirmed = await requestConfirmation('Remove this speed rule?');
+            if (confirmed) {
+                div.remove();
+            }
+        });
 
         div.appendChild(eventSelect);
         div.appendChild(speedSelect);
@@ -275,12 +482,25 @@ document.addEventListener('DOMContentLoaded', () => {
     addRuleBtn.addEventListener('click', () => createRuleRow());
     addSiteRuleBtn.addEventListener('click', () => createSiteRuleRow());
 
+    if (addValidationTermButton) {
+        addValidationTermButton.addEventListener('click', () => {
+            const input = createValidationRow();
+            if (input) {
+                setTimeout(() => input.focus(), 50);
+            }
+        });
+    }
+
+    if (validationFilterToggle) {
+        validationFilterToggle.addEventListener('change', updateValidationEnabled);
+    }
+
     smartSkipToggle.addEventListener('change', updateSkipEnabled);
     simpleSkipToggle.addEventListener('change', updateSimpleSkipEnabled);
     loopToggle.addEventListener('change', updateLoopEnabled);
     scanToggle.addEventListener('change', updateScanEnabled);
 
-    chrome.storage.sync.get({ customSpeedRules: [], skipDelay: 0, smartSkipEnabled: false, simpleAutoSkipEnabled: false, simpleAutoSkipDelay: 5, keyDelay: 2, loopingEnabled: false, loopReset: 10, loopHold: 5, loopFollow: true, siteRules: {}, scanningEnabled: false, scanHotkey: 'Ctrl+Shift+K', scanDuration: 60 }, data => {
+    chrome.storage.sync.get({ customSpeedRules: [], skipDelay: 0, smartSkipEnabled: false, simpleAutoSkipEnabled: false, simpleAutoSkipDelay: 5, keyDelay: 2, loopingEnabled: false, loopReset: 10, loopHold: 5, loopFollow: true, siteRules: {}, scanningEnabled: false, scanHotkey: 'Ctrl+Shift+K', scanDuration: 60, validationVocabulary: DEFAULT_VALIDATION_VOCABULARY, validationFilterEnabled: true }, data => {
         const rules = data.customSpeedRules;
         if (rules.length === 0) {
             createRuleRow();
@@ -303,10 +523,18 @@ document.addEventListener('DOMContentLoaded', () => {
         scanToggle.checked = data.scanningEnabled;
         scanHotkeyInput.value = data.scanHotkey || 'Ctrl+Shift+K';
         scanDurationInput.value = data.scanDuration ?? 60;
+        const validations = sanitizeVocabularyInput(data.validationVocabulary, { fallback: true });
+        if (validationListContainer) {
+            validations.forEach((entry) => createValidationRow(entry));
+        }
+        if (validationFilterToggle) {
+            validationFilterToggle.checked = data.validationFilterEnabled ?? true;
+        }
         updateSkipEnabled();
         updateSimpleSkipEnabled();
         updateLoopEnabled();
         updateScanEnabled();
+        updateValidationEnabled();
     });
 
     saveBtn.addEventListener('click', () => {
@@ -335,6 +563,30 @@ document.addEventListener('DOMContentLoaded', () => {
         scanDurationInput.value = scanDuration;
         const scanHotkey = scanHotkeyInput.value || 'Ctrl+Shift+K';
 
+        const vocabularyEntries = [];
+        if (validationListContainer) {
+            validationListContainer.querySelectorAll('.validation-row').forEach((row) => {
+                const labelInput = row.querySelector('.validation-label');
+                const keywordsInput = row.querySelector('.validation-keywords');
+                const label = labelInput ? labelInput.value.trim() : '';
+                if (!label) {
+                    return;
+                }
+
+                const keywords = keywordsInput
+                    ? keywordsInput.value
+                          .split(',')
+                          .map((keyword) => keyword.trim())
+                          .filter(Boolean)
+                    : [];
+
+                vocabularyEntries.push({ label, keywords });
+            });
+        }
+
+        const sanitizedVocabulary = sanitizeVocabularyInput(vocabularyEntries, { fallback: false });
+        const validationFilterEnabled = validationFilterToggle ? validationFilterToggle.checked : true;
+
         const siteRules = {};
         siteRulesContainer.querySelectorAll('.site-rule').forEach(div => {
             const url = div.querySelector('.url').value.trim();
@@ -356,7 +608,7 @@ document.addEventListener('DOMContentLoaded', () => {
             siteRules[url] = cfg;
         });
 
-        chrome.storage.sync.set({ customSpeedRules: rules, skipDelay: delay, smartSkipEnabled: enabled, simpleAutoSkipEnabled: simpleEnabled, simpleAutoSkipDelay: simpleDelay, keyDelay, loopingEnabled, loopReset: parseFloat(loopResetInput.value) || 10, loopHold: parseFloat(loopHoldInput.value) || 5, loopFollow: loopFollowToggle.checked, siteRules, scanningEnabled: scanEnabled, scanHotkey, scanDuration }, () => {
+        chrome.storage.sync.set({ customSpeedRules: rules, skipDelay: delay, smartSkipEnabled: enabled, simpleAutoSkipEnabled: simpleEnabled, simpleAutoSkipDelay: simpleDelay, keyDelay, loopingEnabled, loopReset: parseFloat(loopResetInput.value) || 10, loopHold: parseFloat(loopHoldInput.value) || 5, loopFollow: loopFollowToggle.checked, siteRules, scanningEnabled: scanEnabled, scanHotkey, scanDuration, validationVocabulary: sanitizedVocabulary, validationFilterEnabled }, () => {
             chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
                 if (tabs[0]) {
                     chrome.tabs.sendMessage(tabs[0].id, {
@@ -373,11 +625,13 @@ document.addEventListener('DOMContentLoaded', () => {
                         siteRules,
                         scanningEnabled: scanEnabled,
                         scanHotkey,
-                        scanDuration
+                        scanDuration,
+                        validationVocabulary: sanitizedVocabulary,
+                        validationFilterEnabled,
                     });
                 }
             });
-            alert('Settings saved');
+            showToast('Settings saved');
         });
     });
 });

--- a/site-info.html
+++ b/site-info.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Project Time Weaver · Site Info</title>
+    <title>QA Assist · Site Info</title>
     <style>
         :root {
             color-scheme: dark;
@@ -27,6 +27,32 @@
             font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
             background: linear-gradient(160deg, rgba(76, 141, 255, 0.08), transparent 55%), var(--bg);
             color: var(--text);
+        }
+
+        .top-nav {
+            display: inline-flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-bottom: 28px;
+        }
+
+        .top-nav a {
+            padding: 8px 14px;
+            border-radius: 999px;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            background: rgba(255, 255, 255, 0.06);
+            color: var(--text);
+            text-decoration: none;
+            font-size: 13px;
+            font-weight: 600;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        .top-nav a:hover,
+        .top-nav a:focus {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+            outline: none;
         }
 
         h1 {
@@ -208,9 +234,16 @@
     </style>
 </head>
 <body>
+    <nav class="top-nav" aria-label="QA Assist navigation">
+        <a href="log.html">Event Log</a>
+        <a href="settings.html">Settings</a>
+        <a href="site-overrides.html">Site Overrides</a>
+        <a href="site-info.html">Site Info</a>
+    </nav>
+
     <header>
         <h1>Site Information Directory</h1>
-        <p>Manage the site aliases used across Project Time Weaver. Each entry maps a human-readable site name to the address or IP detected in the event logs.</p>
+        <p>Manage the site aliases used across QA Assist. Each entry maps a human-readable site name to the address or IP detected in the event logs.</p>
     </header>
 
     <section class="card">

--- a/site-overrides.html
+++ b/site-overrides.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Project Time Weaver · Site Overrides</title>
+    <title>QA Assist · Site Overrides</title>
     <style>
         :root {
             color-scheme: dark;
@@ -27,6 +27,32 @@
             font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
             background: radial-gradient(circle at top right, rgba(76, 141, 255, 0.12), transparent 55%), var(--bg);
             color: var(--text);
+        }
+
+        .top-nav {
+            display: inline-flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-bottom: 32px;
+        }
+
+        .top-nav a {
+            padding: 8px 14px;
+            border-radius: 999px;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            background: rgba(255, 255, 255, 0.06);
+            color: var(--text);
+            text-decoration: none;
+            font-size: 13px;
+            font-weight: 600;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        .top-nav a:hover,
+        .top-nav a:focus {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+            outline: none;
         }
 
         h1 {
@@ -305,6 +331,10 @@
             box-shadow: 0 48px 80px rgba(0, 0, 0, 0.45);
         }
 
+        .modal-card.compact {
+            width: min(420px, 100%);
+        }
+
         .modal-card h3 {
             margin: 0 0 18px;
         }
@@ -342,6 +372,13 @@
     </style>
 </head>
 <body>
+    <nav class="top-nav" aria-label="QA Assist navigation">
+        <a href="log.html">Event Log</a>
+        <a href="settings.html">Settings</a>
+        <a href="site-overrides.html">Site Overrides</a>
+        <a href="site-info.html">Site Info</a>
+    </nav>
+
     <header>
         <h1>Site Overrides</h1>
         <p>Create site-specific behaviours for playback, automation, and scanning. Overrides are applied whenever the current tab matches the configured domain.</p>
@@ -500,6 +537,17 @@
             <div class="modal-footer">
                 <button class="ghost" id="cancelEdit">Cancel</button>
                 <button class="primary" id="saveEdit">Save Changes</button>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal" id="overrideConfirmModal" aria-hidden="true">
+        <div class="modal-card compact">
+            <h3>Delete Override</h3>
+            <p id="overrideConfirmMessage" style="color: var(--muted); margin-bottom: 18px;">Are you sure you want to remove this override?</p>
+            <div class="modal-footer">
+                <button class="ghost" id="overrideConfirmCancel">Cancel</button>
+                <button class="primary" id="overrideConfirmAccept">Delete</button>
             </div>
         </div>
     </div>

--- a/site-overrides.js
+++ b/site-overrides.js
@@ -29,10 +29,15 @@ document.addEventListener("DOMContentLoaded", () => {
     const cancelEditButton = document.getElementById("cancelEdit");
 
     const toast = document.getElementById("overrideToast");
+    const confirmModal = document.getElementById("overrideConfirmModal");
+    const confirmMessage = document.getElementById("overrideConfirmMessage");
+    const confirmAcceptButton = document.getElementById("overrideConfirmAccept");
+    const confirmCancelButton = document.getElementById("overrideConfirmCancel");
 
     let overrides = [];
     let editingId = null;
     let toastTimeout = null;
+    let pendingDeleteId = null;
 
     function generateId() {
         if (typeof crypto !== "undefined" && crypto.randomUUID) {
@@ -172,18 +177,38 @@ document.addEventListener("DOMContentLoaded", () => {
             });
     }
 
+    function closeConfirmModal() {
+        if (!confirmModal) {
+            return;
+        }
+        confirmModal.classList.remove("show");
+        pendingDeleteId = null;
+    }
+
+    function openConfirmModal(message) {
+        if (!confirmModal) {
+            return;
+        }
+
+        if (confirmMessage) {
+            confirmMessage.textContent = message;
+        }
+
+        confirmModal.classList.add("show");
+        setTimeout(() => confirmAcceptButton && confirmAcceptButton.focus(), 100);
+    }
+
     function deleteOverride(id) {
-        const index = overrides.findIndex((override) => override.id === id);
-        if (index === -1) {
+        const override = overrides.find((entry) => entry.id === id);
+        if (!override) {
             return;
         }
-        if (!confirm("Delete this override?")) {
-            return;
-        }
-        overrides.splice(index, 1);
-        saveOverrides();
-        renderOverrides();
-        showToast("Override removed");
+
+        pendingDeleteId = id;
+        const message = override.name
+            ? `Remove override "${override.name}"?`
+            : "Remove this override?";
+        openConfirmModal(message);
     }
 
     function collectFormData(inputs) {
@@ -338,8 +363,56 @@ document.addEventListener("DOMContentLoaded", () => {
     cancelEditButton.addEventListener("click", closeEditModal);
     saveEditButton.addEventListener("click", saveEdit);
 
+    if (confirmAcceptButton) {
+        confirmAcceptButton.addEventListener("click", () => {
+            if (!pendingDeleteId) {
+                closeConfirmModal();
+                return;
+            }
+
+            const index = overrides.findIndex((override) => override.id === pendingDeleteId);
+            if (index !== -1) {
+                overrides.splice(index, 1);
+                saveOverrides();
+                renderOverrides();
+                showToast("Override removed");
+            }
+
+            closeConfirmModal();
+        });
+    }
+
+    if (confirmCancelButton) {
+        confirmCancelButton.addEventListener("click", () => {
+            closeConfirmModal();
+        });
+    }
+
     editModal.addEventListener("click", (event) => {
         if (event.target === editModal) {
+            closeEditModal();
+        }
+    });
+
+    if (confirmModal) {
+        confirmModal.addEventListener("click", (event) => {
+            if (event.target === confirmModal) {
+                closeConfirmModal();
+            }
+        });
+    }
+
+    window.addEventListener("keydown", (event) => {
+        if (event.key !== "Escape") {
+            return;
+        }
+
+        if (confirmModal && confirmModal.classList.contains("show")) {
+            closeConfirmModal();
+            return;
+        }
+
+        if (editModal.classList.contains("show")) {
             closeEditModal();
         }
     });


### PR DESCRIPTION
## Summary
- add a settings panel section with toggleable validation filtering, editable vocabulary rows, and shared confirmation modal styling
- persist custom validation keywords, gate removal actions behind confirmations, and broadcast the new preferences alongside existing options
- teach the content and log views to honor the stored validation list and toggle, refresh when storage changes, and require confirmation before removing bookmarks

## Testing
- not run (UI-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d478d952d8832397fdcb261e961615