### PR TITLE
Adjust event log columns and modal layout

### DIFF
--- a/log.html
+++ b/log.html
@@ -65,6 +65,30 @@
             min-height: 120px;
         }
 
+        .event-id-cell {
+            font-weight: 600;
+            font-size: 14px;
+        }
+
+        .event-meta {
+            color: var(--muted);
+            font-size: 12px;
+            margin-top: 4px;
+        }
+
+        .event-meta-link {
+            color: var(--accent);
+            font-size: 12px;
+            display: inline-block;
+            margin-top: 4px;
+            text-decoration: none;
+            word-break: break-all;
+        }
+
+        .event-meta-link:hover {
+            text-decoration: underline;
+        }
+
         .error-text {
             color: var(--danger);
             font-size: 12px;
@@ -169,7 +193,7 @@
                 <table>
                     <thead>
                         <tr>
-                            <th>Event</th>
+                            <th>Event ID</th>
                             <th>Validation</th>
                             <th>Timestamp</th>
                             <th>Site</th>
@@ -194,7 +218,7 @@
                 <table>
                     <thead>
                         <tr>
-                            <th>Event</th>
+                            <th>Event ID</th>
                             <th>Validation</th>
                             <th>Timestamp</th>
                             <th>Site</th>

--- a/log.js
+++ b/log.js
@@ -565,26 +565,45 @@ document.addEventListener("DOMContentLoaded", () => {
         const row = document.createElement("tr");
 
         const eventCell = document.createElement("td");
-        eventCell.innerHTML = `<div>${log.eventType || "—"}</div><div class="badge" style="margin-top:6px;">${
-            log.eventId || "ID unavailable"
-        }</div>`;
+        const eventId = log.eventId || "—";
+        const eventType = log.eventType || "—";
+        const eventIdDisplay = document.createElement("div");
+        eventIdDisplay.className = "event-id-cell";
+        eventIdDisplay.textContent = eventId;
+        const eventTypeDisplay = document.createElement("div");
+        eventTypeDisplay.className = "event-meta";
+        eventTypeDisplay.textContent = eventType;
+        eventCell.appendChild(eventIdDisplay);
+        eventCell.appendChild(eventTypeDisplay);
 
-        const truckCell = document.createElement("td");
-        truckCell.textContent = log.truckNumber || "—";
-
-        const timestampCell = document.createElement("td");
-        timestampCell.textContent = log.timestamp || "—";
+        if (log.truckNumber) {
+            const truckDisplay = document.createElement("div");
+            truckDisplay.className = "event-meta";
+            truckDisplay.textContent = `Truck ${log.truckNumber}`;
+            eventCell.appendChild(truckDisplay);
+        }
 
         const validationCell = document.createElement("td");
         validationCell.textContent = getRawValidation(log) || "—";
 
-        const siteCell = document.createElement("td");
-        siteCell.textContent = (log.siteName || "—").trim();
+        const timestampCell = document.createElement("td");
+        timestampCell.textContent = log.timestamp || "—";
 
-        const pageCell = document.createElement("td");
-        pageCell.innerHTML = log.pageUrl
-            ? `<a href="${log.pageUrl}" target="_blank">${log.pageUrl}</a>`
-            : "—";
+        const siteCell = document.createElement("td");
+        const siteNameDisplay = document.createElement("div");
+        const siteName = (log.siteName || "").trim();
+        siteNameDisplay.textContent = siteName || "—";
+        siteCell.appendChild(siteNameDisplay);
+
+        if (log.pageUrl) {
+            const pageLink = document.createElement("a");
+            pageLink.href = log.pageUrl;
+            pageLink.target = "_blank";
+            pageLink.rel = "noopener noreferrer";
+            pageLink.textContent = log.pageUrl;
+            pageLink.className = "event-meta-link";
+            siteCell.appendChild(pageLink);
+        }
 
         const commentCell = document.createElement("td");
         commentCell.textContent = log.comment || "";
@@ -594,11 +613,9 @@ document.addEventListener("DOMContentLoaded", () => {
         actionsCell.appendChild(createCallButton(log));
 
         row.appendChild(eventCell);
-        row.appendChild(truckCell);
-        row.appendChild(timestampCell);
         row.appendChild(validationCell);
+        row.appendChild(timestampCell);
         row.appendChild(siteCell);
-        row.appendChild(pageCell);
         row.appendChild(commentCell);
         row.appendChild(actionsCell);
 
@@ -609,10 +626,15 @@ document.addEventListener("DOMContentLoaded", () => {
         const row = document.createElement("tr");
 
         const eventIdCell = document.createElement("td");
-        eventIdCell.textContent = log.eventId || "—";
+        const eventIdValue = document.createElement("div");
+        eventIdValue.className = "event-id-cell";
+        eventIdValue.textContent = log.eventId || "—";
+        eventIdCell.appendChild(eventIdValue);
 
-        const eventTypeCell = document.createElement("td");
-        eventTypeCell.textContent = log.eventType || "—";
+        const eventTypeDisplay = document.createElement("div");
+        eventTypeDisplay.className = "event-meta";
+        eventTypeDisplay.textContent = log.eventType || "—";
+        eventIdCell.appendChild(eventTypeDisplay);
 
         const truckCell = document.createElement("td");
         truckCell.textContent = log.truckNumber || "—";
@@ -621,22 +643,24 @@ document.addEventListener("DOMContentLoaded", () => {
         timestampCell.textContent = log.timestamp || "—";
 
         const siteCell = document.createElement("td");
-        siteCell.textContent = (log.siteName || "—").trim();
+        const siteNameDisplay = document.createElement("div");
+        const siteName = (log.siteName || "").trim();
+        siteNameDisplay.textContent = siteName || "—";
+        siteCell.appendChild(siteNameDisplay);
 
-        const pageCell = document.createElement("td");
-        pageCell.innerHTML = log.pageUrl
-            ? `<a href="${log.pageUrl}" target="_blank">${log.pageUrl}</a>`
-            : "—";
+        if (log.pageUrl) {
+            const pageLink = document.createElement("a");
+            pageLink.href = log.pageUrl;
+            pageLink.target = "_blank";
+            pageLink.rel = "noopener noreferrer";
+            pageLink.textContent = log.pageUrl;
+            pageLink.className = "event-meta-link";
+            siteCell.appendChild(pageLink);
+        }
 
         const validationCell = document.createElement("td");
         const validationText = getRawValidation(log);
         validationCell.textContent = validationText || "—";
-
-        const callsCell = document.createElement("td");
-        const attempts = Array.isArray(log.callHistory) ? log.callHistory.length : 0;
-        callsCell.innerHTML = attempts
-            ? `<span class="badge success">${attempts} Call${attempts > 1 ? "s" : ""}</span>`
-            : "—";
 
         const actionsCell = document.createElement("td");
         actionsCell.style.display = "flex";
@@ -645,13 +669,10 @@ document.addEventListener("DOMContentLoaded", () => {
         actionsCell.appendChild(createCallButton(log));
 
         row.appendChild(eventIdCell);
-        row.appendChild(eventTypeCell);
-        row.appendChild(truckCell);
+        row.appendChild(validationCell);
         row.appendChild(timestampCell);
         row.appendChild(siteCell);
-        row.appendChild(pageCell);
-        row.appendChild(validationCell);
-        row.appendChild(callsCell);
+        row.appendChild(truckCell);
         row.appendChild(actionsCell);
 
         return row;
@@ -975,7 +996,6 @@ document.addEventListener("DOMContentLoaded", () => {
             "Timestamp",
             "Site",
             "Page URL",
-            "Calls",
             "Validation Type",
             "Monitor Name",
             "Last Contact",
@@ -993,7 +1013,6 @@ document.addEventListener("DOMContentLoaded", () => {
                     log.timestamp || "",
                     (log.siteName || "").trim(),
                     log.pageUrl || "",
-                    attempts,
                     getRawValidation(log),
                     log.monitorName || "",
                     lastAttempt ? (lastAttempt.contactMade ? "Contacted" : "No Contact") : "",

--- a/styles.css
+++ b/styles.css
@@ -378,6 +378,7 @@ button:hover {
     align-items: center;
     justify-content: center;
     padding: 24px;
+    overflow-y: auto;
     z-index: 50;
 }
 
@@ -396,6 +397,13 @@ button:hover {
     gap: 16px;
     box-shadow: 0 32px 60px rgba(0, 0, 0, 0.35);
     position: relative;
+}
+
+#callModal .modal-content {
+    width: min(640px, 95vw);
+    max-height: min(80vh, 640px);
+    overflow-y: auto;
+    padding: 28px;
 }
 
 .modal-close,


### PR DESCRIPTION
## Summary
- relabel the event log tables to display “Event ID” with supporting metadata inline
- drop the redundant call-count column and keep CSV exports aligned with the visible columns
- constrain the call validation modal to a scrollable, rectangular layout that fits on smaller screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5c406695c8323a07e70c541afd049