### PR TITLE
Support OAS Mode detection and logging; add playback controls and settings toggle

### DIFF
--- a/QA Assist v1.1/background.js
+++ b/QA Assist v1.1/background.js
@@ -46,6 +46,7 @@ const STORAGE_MIGRATION_KEYS = [
     "keyDelay",
     "autoLoopDelay",
     "autoLoopHold",
+    "oasModeEnabled",
     "siteRules",
     "validationVocabulary",
     "validationFilterEnabled",

--- a/QA Assist v1.1/content.js
+++ b/QA Assist v1.1/content.js
@@ -1267,11 +1267,21 @@ function handleSelectionChange() {
 
 function observeSelectionChanges() {
     const observer = new MutationObserver((mutations) => {
-        if (
-            mutations.some((mutation) =>
-                mutation.type === "attributes" && mutation.target.classList.contains("gvEventListItemPadding"),
-            )
-        ) {
+        const hasClassicSelectionChange = mutations.some(
+            (mutation) =>
+                mutation.type === "attributes" &&
+                mutation.target.classList.contains("gvEventListItemPadding"),
+        );
+        const hasOasSelectionChange = state.oasMode
+            ? mutations.some(
+                  (mutation) =>
+                      mutation.type === "attributes" &&
+                      mutation.target.classList.contains("item") &&
+                      mutation.target.closest(".List"),
+              )
+            : false;
+
+        if (hasClassicSelectionChange || hasOasSelectionChange) {
             handleSelectionChange();
         }
     });

--- a/QA Assist v1.1/content.js
+++ b/QA Assist v1.1/content.js
@@ -323,18 +323,8 @@ function removeEyeTrackerElements() {
     });
 }
 
-function findOasEquipmentName(root = document) {
-    const sections = Array.from(root.querySelectorAll(".Accordion > div"));
-    const section = sections.find((entry) => {
-        const headerText = entry.querySelector(".header .text")?.textContent?.trim() || "";
-        return headerText.includes("Equipment Detail");
-    });
-
-    if (!section) {
-        return "";
-    }
-
-    const row = Array.from(section.querySelectorAll(".container")).find(
+function findOasTruckNameFromContainers(root = document) {
+    const row = Array.from(root.querySelectorAll(".container")).find(
         (container) => container.querySelector(".type")?.textContent?.trim() === "Name",
     );
     return row?.querySelector(".data")?.textContent?.trim() || "";
@@ -426,8 +416,9 @@ function collectEventDetails(video, options = {}) {
             }
         });
 
-        if (!truckNumber) {
-            truckNumber = findOasEquipmentName(oasDetailRoot || document);
+        const containerTruckNumber = findOasTruckNameFromContainers(document);
+        if (containerTruckNumber) {
+            truckNumber = containerTruckNumber;
         }
 
         if (!validationType) {

--- a/QA Assist v1.1/content.js
+++ b/QA Assist v1.1/content.js
@@ -323,6 +323,23 @@ function removeEyeTrackerElements() {
     });
 }
 
+function findOasEquipmentName(root = document) {
+    const sections = Array.from(root.querySelectorAll(".Accordion > div"));
+    const section = sections.find((entry) => {
+        const headerText = entry.querySelector(".header .text")?.textContent?.trim() || "";
+        return headerText.includes("Equipment Detail");
+    });
+
+    if (!section) {
+        return "";
+    }
+
+    const row = Array.from(section.querySelectorAll(".container")).find(
+        (container) => container.querySelector(".type")?.textContent?.trim() === "Name",
+    );
+    return row?.querySelector(".data")?.textContent?.trim() || "";
+}
+
 function collectEventDetails(video, options = {}) {
     const suppressWarnings = Boolean(options && options.suppressWarnings);
     const allRows = document.querySelectorAll(".gvEventListItemPadding");
@@ -410,20 +427,7 @@ function collectEventDetails(video, options = {}) {
         });
 
         if (!truckNumber) {
-            const containerScope = oasDetailRoot || document;
-            const nameEntries = Array.from(containerScope.querySelectorAll(".container"))
-                .filter((container) => {
-                    const typeNode = container.querySelector(".type");
-                    return typeNode && typeNode.textContent.trim() === "Name";
-                })
-                .map((container) => {
-                    const dataNode = container.querySelector(".data");
-                    return dataNode ? dataNode.textContent.trim() : "";
-                })
-                .filter(Boolean);
-            if (nameEntries.length) {
-                truckNumber = nameEntries[0];
-            }
+            truckNumber = findOasEquipmentName(oasDetailRoot || document);
         }
 
         if (!validationType) {

--- a/QA Assist v1.1/content.js
+++ b/QA Assist v1.1/content.js
@@ -7,6 +7,11 @@ const REQUIRED_CLASS_SELECTORS = [
     ".gvEventListItemPadding.selected.primarysel",
 ];
 
+const OAS_REQUIRED_SELECTORS = [
+    ".List .content",
+    ".List .item .Thumbnail .image-container",
+];
+
 const DEFAULT_VALIDATION_VOCABULARY = [
     { label: "Blocked", keywords: ["blocked"] },
     { label: "Critical", keywords: ["critical"] },
@@ -35,6 +40,7 @@ const state = {
     bufferDelay: 4,
     autoLoopDelay: 8,
     autoLoopHold: 5,
+    oasMode: false,
     removeEyeTracker: false,
     antiLagEnabled: false,
     antiLagSeekSeconds: DEFAULT_ANTI_LAG_SEEK,
@@ -334,7 +340,59 @@ function collectEventDetails(video, options = {}) {
     let isLastCell = false;
     let validationType = "";
 
-    if (isHideTracking) {
+    if (state.oasMode) {
+        const selectedItem = document.querySelector(".List .item.selected");
+        if (!selectedItem) {
+            if (!suppressWarnings) {
+                console.warn("⚠️ No selected OAS item found for event logging.");
+            }
+            return null;
+        }
+
+        const items = Array.from(document.querySelectorAll(".List .item"));
+        if (items.length) {
+            isLastCell = selectedItem === items[items.length - 1];
+        }
+
+        const eventTypeElement = selectedItem.querySelector("label.field.event_type, label.field-event_type");
+        const timestampElement = selectedItem.querySelector("label.field-created_at, label.field.created_at");
+        const validationElement = selectedItem.querySelector("label.field-reviewed_type, label.field.reviewed_type");
+        const eventIdElement = selectedItem.querySelector("label.field-eventid, label.field-event_id");
+
+        if (eventTypeElement) {
+            eventType = eventTypeElement.textContent.trim();
+        }
+        if (timestampElement) {
+            timestamp = timestampElement.textContent.trim();
+        }
+        if (validationElement) {
+            validationType = validationElement.textContent.trim();
+        }
+        if (eventIdElement) {
+            eventId = eventIdElement.textContent.trim();
+        }
+
+        const fieldContainers = Array.from(document.querySelectorAll(".Fields .fields .container"));
+        fieldContainers.forEach((container) => {
+            const typeNode = container.querySelector(".type");
+            const dataNode = container.querySelector(".data");
+            const label = typeNode ? typeNode.textContent.trim().toLowerCase() : "";
+            const value = dataNode ? dataNode.textContent.trim() : "";
+            if (!value) {
+                return;
+            }
+            if (label === "name" && !truckNumber) {
+                truckNumber = value;
+            }
+            if (label === "operator" && !operatorName) {
+                operatorName = value;
+            }
+        });
+
+        if (!validationType) {
+            validationType = extractValidationFromContainer(selectedItem);
+        }
+    } else if (isHideTracking) {
         const selectedItem = document.querySelector(".item.selected");
 
         if (selectedItem) {
@@ -757,8 +815,9 @@ function startBufferTimer(signature, eventData) {
         if (state.pendingBufferSignature && state.pendingBufferSignature !== state.lastEventSignature) {
             return;
         }
-        pressKey("ArrowDown");
-        if (state.autoPressNext && eventData?.isLastCell) {
+        const advanceKey = state.oasMode ? "ArrowRight" : "ArrowDown";
+        pressKey(advanceKey);
+        if (!state.oasMode && state.autoPressNext && eventData?.isLastCell) {
             setTimeout(() => pressKey("ArrowRight"), 600);
         }
     }, delay);
@@ -849,7 +908,8 @@ function stopAutomationLoop() {
 }
 
 function detectRequiredElements() {
-    const hasElement = REQUIRED_CLASS_SELECTORS.some((selector) => Boolean(document.querySelector(selector)));
+    const selectors = state.oasMode ? OAS_REQUIRED_SELECTORS : REQUIRED_CLASS_SELECTORS;
+    const hasElement = selectors.some((selector) => Boolean(document.querySelector(selector)));
     if (hasElement !== state.hasRequiredElements) {
         state.hasRequiredElements = hasElement;
         updateMode();
@@ -889,6 +949,33 @@ function updateAllVideoPlaybackRates() {
             console.warn("Unable to update playback speed", error);
         }
     });
+}
+
+function applyPlaybackCommand(command) {
+    if (!state.enabled) {
+        return false;
+    }
+    const videos = document.querySelectorAll("video.gvVideo.controllerless, .videos.hide-tracking video");
+    if (!videos.length) {
+        return false;
+    }
+    let updated = false;
+    videos.forEach((video) => {
+        if (command === "pause") {
+            if (!video.paused) {
+                video.pause();
+            }
+            updated = true;
+        } else if (command === "play") {
+            applyPlaybackSpeed(video);
+            const playPromise = video.play();
+            if (playPromise && typeof playPromise.catch === "function") {
+                playPromise.catch(() => {});
+            }
+            updated = true;
+        }
+    });
+    return updated;
 }
 
 function getLagState(video) {
@@ -1213,6 +1300,7 @@ function getStatusSnapshot() {
         bufferDelay: state.bufferDelay,
         autoLoopDelay: state.autoLoopDelay,
         autoLoopHold: state.autoLoopHold,
+        oasMode: state.oasMode,
         universalSpeed: state.universalSpeed,
         antiLagEnabled: state.antiLagEnabled,
         antiLagSeekSeconds: state.antiLagSeekSeconds,
@@ -1315,6 +1403,7 @@ function applySettings(data) {
     state.bufferDelay = parsePositiveNumber(data.keyDelay, 4);
     state.autoLoopDelay = parsePositiveNumber(data.autoLoopDelay, 8);
     state.autoLoopHold = parsePositiveNumber(data.autoLoopHold, 5);
+    state.oasMode = normalizeBoolean(data.oasModeEnabled, false);
     state.antiLagEnabled = normalizeBoolean(data.antiLagEnabled, state.antiLagEnabled);
     state.antiLagSeekSeconds = parsePositiveNumber(
         data.antiLagSeekSeconds,
@@ -1322,6 +1411,7 @@ function applySettings(data) {
     );
     applyValidationPreferences(data.validationVocabulary || DEFAULT_VALIDATION_VOCABULARY, data.validationFilterEnabled);
 
+    detectRequiredElements();
     setAutoMode(data.autoModeEnabled);
     setAutoPressNext(data.autoPressNext);
     setAutoLoop(data.autoLoopEnabled);
@@ -1382,6 +1472,7 @@ function handleStorageChange(changes, areaName) {
         changes.keyDelay ||
         changes.autoLoopDelay ||
         changes.autoLoopHold ||
+        changes.oasModeEnabled ||
         changes.validationVocabulary ||
         changes.validationFilterEnabled ||
         changes.playbackSpeed ||
@@ -1401,6 +1492,7 @@ function handleStorageChange(changes, areaName) {
                 keyDelay: state.bufferDelay,
                 autoLoopDelay: state.autoLoopDelay,
                 autoLoopHold: state.autoLoopHold,
+                oasModeEnabled: state.oasMode,
                 validationVocabulary: state.validationVocabulary,
                 validationFilterEnabled: state.validationFilterEnabled,
                 removeEyeTracker: state.removeEyeTracker,
@@ -1436,6 +1528,7 @@ function initialize() {
             keyDelay: 4,
             autoLoopDelay: 8,
             autoLoopHold: 5,
+            oasModeEnabled: false,
             validationVocabulary: DEFAULT_VALIDATION_VOCABULARY,
             validationFilterEnabled: true,
             antiLagEnabled: false,
@@ -1528,6 +1621,17 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 siteName: logEntry.siteName || state.siteName || "",
             });
         });
+        return true;
+    }
+
+    if (message.type === "qaAssist:playbackCommand") {
+        const action = typeof message.action === "string" ? message.action : "";
+        if (action !== "pause" && action !== "play") {
+            sendResponse?.({ success: false, reason: "invalid" });
+            return true;
+        }
+        const handled = applyPlaybackCommand(action);
+        sendResponse?.({ success: handled });
         return true;
     }
 

--- a/QA Assist v1.1/content.js
+++ b/QA Assist v1.1/content.js
@@ -339,6 +339,7 @@ function collectEventDetails(video, options = {}) {
     const pageUrl = getPageUrl();
     let isLastCell = false;
     let validationType = "";
+    let oasDetailRoot = null;
 
     if (state.oasMode) {
         const selectedItem = document.querySelector(".List .item.selected");
@@ -349,15 +350,26 @@ function collectEventDetails(video, options = {}) {
             return null;
         }
 
-        const items = Array.from(document.querySelectorAll(".List .item"));
+        const listRoot = selectedItem.closest(".List");
+        const items = Array.from(listRoot ? listRoot.querySelectorAll(".item") : []);
         if (items.length) {
             isLastCell = selectedItem === items[items.length - 1];
         }
 
-        const eventTypeElement = selectedItem.querySelector("label.field.event_type, label.field-event_type");
-        const timestampElement = selectedItem.querySelector("label.field-created_at, label.field.created_at");
-        const validationElement = selectedItem.querySelector("label.field-reviewed_type, label.field.reviewed_type");
-        const eventIdElement = selectedItem.querySelector("label.field-eventid, label.field-event_id");
+        oasDetailRoot = listRoot?.parentElement || selectedItem.parentElement || null;
+        const lookupRoot = oasDetailRoot || selectedItem;
+        const eventTypeElement =
+            selectedItem.querySelector("label.field.event_type, label.field-event_type") ||
+            lookupRoot.querySelector("label.field.event_type, label.field-event_type");
+        const timestampElement =
+            selectedItem.querySelector("label.field-created_at, label.field.created_at") ||
+            lookupRoot.querySelector("label.field-created_at, label.field.created_at");
+        const validationElement =
+            selectedItem.querySelector("label.field-reviewed_type, label.field.reviewed_type") ||
+            lookupRoot.querySelector("label.field-reviewed_type, label.field.reviewed_type");
+        const eventIdElement =
+            selectedItem.querySelector("label.field-eventid, label.field-event_id") ||
+            lookupRoot.querySelector("label.field-eventid, label.field-event_id");
 
         if (eventTypeElement) {
             eventType = eventTypeElement.textContent.trim();
@@ -372,7 +384,12 @@ function collectEventDetails(video, options = {}) {
             eventId = eventIdElement.textContent.trim();
         }
 
-        const fieldContainers = Array.from(document.querySelectorAll(".Fields .fields .container"));
+        const fieldsRoot =
+            selectedItem.querySelector(".Fields") ||
+            (oasDetailRoot ? oasDetailRoot.querySelector(".Fields") : null);
+        const fieldContainers = fieldsRoot
+            ? Array.from(fieldsRoot.querySelectorAll(".fields .container"))
+            : [];
         fieldContainers.forEach((container) => {
             const typeNode = container.querySelector(".type");
             const dataNode = container.querySelector(".data");
@@ -521,10 +538,11 @@ function collectEventDetails(video, options = {}) {
     }
 
     if (!validationType) {
-        const detailsPanel =
-            document.querySelector(".gvDetailPanel, .gvEventDetails, .event-details, .details-panel") ||
-            selectedRow?.parentElement ||
-            null;
+        const detailsPanel = state.oasMode
+            ? oasDetailRoot
+            : document.querySelector(".gvDetailPanel, .gvEventDetails, .event-details, .details-panel") ||
+              selectedRow?.parentElement ||
+              null;
         validationType = extractValidationFromContainer(detailsPanel) || validationType;
     }
 

--- a/QA Assist v1.1/content.js
+++ b/QA Assist v1.1/content.js
@@ -409,6 +409,23 @@ function collectEventDetails(video, options = {}) {
             }
         });
 
+        if (!truckNumber) {
+            const containerScope = oasDetailRoot || document;
+            const nameEntries = Array.from(containerScope.querySelectorAll(".container"))
+                .filter((container) => {
+                    const typeNode = container.querySelector(".type");
+                    return typeNode && typeNode.textContent.trim() === "Name";
+                })
+                .map((container) => {
+                    const dataNode = container.querySelector(".data");
+                    return dataNode ? dataNode.textContent.trim() : "";
+                })
+                .filter(Boolean);
+            if (nameEntries.length) {
+                truckNumber = nameEntries[0];
+            }
+        }
+
         if (!validationType) {
             validationType = extractValidationFromContainer(selectedItem);
         }

--- a/QA Assist v1.1/content.js
+++ b/QA Assist v1.1/content.js
@@ -401,6 +401,9 @@ function collectEventDetails(video, options = {}) {
             if (label === "name" && !truckNumber) {
                 truckNumber = value;
             }
+            if (label === "equipment" && !truckNumber) {
+                truckNumber = value;
+            }
             if (label === "operator" && !operatorName) {
                 operatorName = value;
             }

--- a/QA Assist v1.1/popup.html
+++ b/QA Assist v1.1/popup.html
@@ -77,6 +77,13 @@
                     <option value="2">2x</option>
                 </select>
             </label>
+            <div class="playback-controls">
+                <span class="playback-label">Universal Playback</span>
+                <div class="playback-buttons">
+                    <button type="button" id="pauseAll" class="mini-button" title="Pause all videos" aria-label="Pause all videos">⏸</button>
+                    <button type="button" id="playAll" class="mini-button" title="Play all videos" aria-label="Play all videos">▶</button>
+                </div>
+            </div>
         </section>
 
         <p id="lostMessage" class="status-note hidden">Required page elements not detected. Refresh the tab or force auto mode.</p>

--- a/QA Assist v1.1/popup.js
+++ b/QA Assist v1.1/popup.js
@@ -13,6 +13,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const removeEyeToggle = document.getElementById("removeEyeToggle");
     const instaLogButton = document.getElementById("instaLog");
     const universalSpeedSelect = document.getElementById("universalSpeedSelect");
+    const pauseAllButton = document.getElementById("pauseAll");
+    const playAllButton = document.getElementById("playAll");
     const lostMessage = document.getElementById("lostMessage");
     const forceAutoButton = document.getElementById("forceAuto");
     const openLogButton = document.getElementById("openLog");
@@ -156,6 +158,12 @@ document.addEventListener("DOMContentLoaded", () => {
         removeEyeToggle.disabled = !extensionActive;
         if (universalSpeedSelect) {
             universalSpeedSelect.disabled = !extensionActive;
+        }
+        if (pauseAllButton) {
+            pauseAllButton.disabled = !extensionActive;
+        }
+        if (playAllButton) {
+            playAllButton.disabled = !extensionActive;
         }
         if (dispatchInput) {
             dispatchInput.disabled = !extensionActive;
@@ -536,6 +544,22 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
 
+    function broadcastPlaybackCommand(action) {
+        if (!currentEnabled) {
+            return;
+        }
+        chrome.tabs.query({}, (tabs) => {
+            if (chrome.runtime.lastError || !Array.isArray(tabs)) {
+                return;
+            }
+            tabs.forEach((tab) => {
+                chrome.tabs.sendMessage(tab.id, { type: "qaAssist:playbackCommand", action }, () => {
+                    chrome.runtime.lastError;
+                });
+            });
+        });
+    }
+
     extensionToggle.addEventListener("change", () => {
         const desiredState = extensionToggle.checked;
         commitEnabledState(desiredState);
@@ -576,6 +600,18 @@ document.addEventListener("DOMContentLoaded", () => {
     if (universalSpeedSelect) {
         universalSpeedSelect.addEventListener("change", () => {
             commitUniversalSpeed(universalSpeedSelect.value);
+        });
+    }
+
+    if (pauseAllButton) {
+        pauseAllButton.addEventListener("click", () => {
+            broadcastPlaybackCommand("pause");
+        });
+    }
+
+    if (playAllButton) {
+        playAllButton.addEventListener("click", () => {
+            broadcastPlaybackCommand("play");
         });
     }
 

--- a/QA Assist v1.1/qa-control.html
+++ b/QA Assist v1.1/qa-control.html
@@ -116,7 +116,7 @@
                 </div>
             </div>
             <div class="card-body">
-                <p class="helper-text">Same-truck events generated less than two minutes apart.</p>
+                <p class="helper-text">Same-truck events with more than two events in a one-minute window.</p>
                 <div id="fluctuationContainer" class="fluctuation-list"></div>
             </div>
         </section>

--- a/QA Assist v1.1/settings.html
+++ b/QA Assist v1.1/settings.html
@@ -78,6 +78,21 @@
 
         <section class="page-card">
             <div class="card-header">
+                <h2>OAS Mode</h2>
+                <div class="card-controls">
+                    <button class="collapse-toggle" type="button" aria-expanded="true" aria-label="Collapse section"></button>
+                </div>
+            </div>
+            <div class="card-body">
+                <label class="toggle-row">
+                    <input id="oasModeToggle" type="checkbox"> <span>Enable OAS Mode</span>
+                </label>
+                <p class="helper-text">Use the right arrow for auto-advance when videos end.</p>
+            </div>
+        </section>
+
+        <section class="page-card">
+            <div class="card-header">
                 <h2>Anti lag</h2>
                 <div class="card-controls">
                     <button class="collapse-toggle" type="button" aria-expanded="true" aria-label="Collapse section"></button>

--- a/QA Assist v1.1/settings.js
+++ b/QA Assist v1.1/settings.js
@@ -31,6 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const loopHoldInput = document.getElementById('loopHold');
     const loopResetContainer = document.getElementById('loopResetContainer');
     const loopHoldContainer = document.getElementById('loopHoldContainer');
+    const oasModeToggle = document.getElementById('oasModeToggle');
     const antiLagToggle = document.getElementById('antiLagToggle');
     const antiLagSeekInput = document.getElementById('antiLagSeek');
     const antiLagSeekContainer = document.getElementById('antiLagSeekContainer');
@@ -285,6 +286,15 @@ document.addEventListener('DOMContentLoaded', () => {
         autoNextLabel.appendChild(autoNext);
         autoNextLabel.append(' Auto Press Next');
 
+        const oasMode = document.createElement('input');
+        oasMode.type = 'checkbox';
+        oasMode.className = 'oasMode';
+        oasMode.checked = rule?.oasModeEnabled || false;
+
+        const oasModeLabel = document.createElement('label');
+        oasModeLabel.appendChild(oasMode);
+        oasModeLabel.append(' OAS Mode');
+
         const removeEye = document.createElement('input');
         removeEye.type = 'checkbox';
         removeEye.className = 'removeEye';
@@ -368,6 +378,7 @@ document.addEventListener('DOMContentLoaded', () => {
             speedLabel,
             keyLabel,
             autoNextLabel,
+            oasModeLabel,
             removeEyeLabel,
             smartSkipLabel,
             keyDelayLabel,
@@ -512,6 +523,7 @@ document.addEventListener('DOMContentLoaded', () => {
             autoLoopEnabled: false,
             autoLoopDelay: 8,
             autoLoopHold: 5,
+            oasModeEnabled: false,
             siteRules: {},
             validationVocabulary: DEFAULT_VALIDATION_VOCABULARY,
             validationFilterEnabled: true,
@@ -532,6 +544,9 @@ document.addEventListener('DOMContentLoaded', () => {
         loopToggle.checked = data.autoLoopEnabled;
         loopResetInput.value = data.autoLoopDelay ?? 8;
         loopHoldInput.value = data.autoLoopHold ?? 5;
+        if (oasModeToggle) {
+            oasModeToggle.checked = data.oasModeEnabled ?? false;
+        }
         if (antiLagToggle) {
             antiLagToggle.checked = data.antiLagEnabled ?? false;
         }
@@ -572,6 +587,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const enabled = smartSkipToggle.checked;
         const autoLoopEnabled = loopToggle.checked;
+        const oasModeEnabled = oasModeToggle ? oasModeToggle.checked : false;
         const antiLagEnabled = antiLagToggle ? antiLagToggle.checked : false;
         const rawAntiLag = parseFloat(antiLagSeekInput?.value);
         const antiLagSeekSeconds = Number.isFinite(rawAntiLag)
@@ -614,6 +630,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 speed: div.querySelector('.speed').value,
                 pressKey: div.querySelector('.key').value,
                 autoPressNext: div.querySelector('.autoNext').checked,
+                oasModeEnabled: div.querySelector('.oasMode').checked,
                 removeEyeTracker: div.querySelector('.removeEye').checked,
                 smartSkipEnabled: div.querySelector('.smartSkip').checked,
                 skipDelay: parseFloat(div.querySelector('.skipDelay').value) || 0,
@@ -634,6 +651,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 autoLoopEnabled,
                 autoLoopDelay: parseFloat(loopResetInput.value) || 8,
                 autoLoopHold: parseFloat(loopHoldInput.value) || 5,
+                oasModeEnabled,
                 siteRules,
                 validationVocabulary: sanitizedVocabulary,
                 validationFilterEnabled,
@@ -651,6 +669,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             autoLoopEnabled,
                             autoLoopDelay: parseFloat(loopResetInput.value) || 8,
                             autoLoopHold: parseFloat(loopHoldInput.value) || 5,
+                            oasModeEnabled,
                             siteRules,
                             validationVocabulary: sanitizedVocabulary,
                             validationFilterEnabled,

--- a/QA Assist v1.1/styles.css
+++ b/QA Assist v1.1/styles.css
@@ -1747,6 +1747,61 @@ body.popup {
     background: rgba(255, 255, 255, 0.02);
 }
 
+.playback-controls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text);
+}
+
+.playback-label {
+    font-size: 11px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+
+.playback-buttons {
+    display: inline-flex;
+    gap: 6px;
+}
+
+.mini-button {
+    width: 28px;
+    height: 24px;
+    border-radius: 7px;
+    border: 1px solid var(--border);
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--text);
+    font-size: 12px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.mini-button:hover,
+.mini-button:focus-visible {
+    background: rgba(255, 255, 255, 0.14);
+    border-color: rgba(255, 255, 255, 0.3);
+    box-shadow: 0 10px 18px rgba(15, 23, 42, 0.35);
+}
+
+.mini-button:focus-visible {
+    outline: 2px solid rgba(76, 141, 255, 0.45);
+    outline-offset: 2px;
+}
+
+.mini-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    box-shadow: none;
+    transform: none;
+}
+
 .toggle-row {
     display: flex;
     align-items: center;


### PR DESCRIPTION
### Motivation
- OAS Mode requires different DOM hooks and event metadata extraction compared to the default UI, so the extension must detect OAS pages and read OAS-specific elements when enabled. 
- Make OAS behavior opt-in via settings and site overrides so auto-advance and logging use the correct keys and fields only when intended. 
- Add simple playback controls to the popup to allow pausing/playing all videos from the extension UI.

### Description
- Added `OAS_REQUIRED_SELECTORS` and switched `detectRequiredElements()` to choose between `REQUIRED_CLASS_SELECTORS` and OAS selectors when `state.oasMode` is active, and re-evaluate required elements after settings are applied via `detectRequiredElements()` in `applySettings`.
- Extended `collectEventDetails()` to support OAS pages when `state.oasMode` is true by locating the selected `.List .item.selected`, reading `label.field.event_type`/`label.field-event_type`, `label.field-reviewed_type`, `label.field-created_at`, event id labels, and parsing `.Fields .fields .container` items for `Name` (truck number) and `Operator` (operator name); fallback validation extraction remains via `extractValidationFromContainer`.
- Changed auto-advance behavior in `startBufferTimer()` to use `ArrowRight` when `state.oasMode` is true and to avoid the extra delayed `ArrowRight` second press when in OAS Mode, preserving the original double-press behavior for non-OAS flows.
- Added `applyPlaybackCommand()` in `content.js` to pause/play all matching videos, and added a popup UI block with `pauseAll`/`playAll` buttons plus corresponding message handling (`qaAssist:playbackCommand`) implemented in `popup.js` and content script messaging.
- Introduced the `oasMode` toggle in `settings.html` and `settings.js` and exposed an `oasModeEnabled` flag per site override; updated background and storage migration handling to include `oasModeEnabled` and propagated the setting into content via `applySettings`.
- Minor UI/UX and analytics updates across `popup.html`, `popup.js`, `styles.css`, `qa-control.html`, `qa-control.js` (fluctuation window/minimum events logic) to support the new playback controls and tweak some control text.
- Files changed (key): `content.js`, `settings.html`, `settings.js`, `background.js`, `popup.html`, `popup.js`, `styles.css`, `qa-control.js`, `qa-control.html`.

### Testing
- No automated unit/integration tests were executed for these changes; no test suite was run against the modified code.
- Changes were validated via code inspection and adjusted logic to preserve backward compatibility when `oasMode` is not enabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69836c4cc3888325bafe5cb8341de84a)