### PR TITLE
Move event logs to IndexedDB, dedupe analytics, add site health & truck-focused UI

### DIFF
--- a/QA Assist v1.1/background.js
+++ b/QA Assist v1.1/background.js
@@ -46,6 +46,7 @@ const STORAGE_MIGRATION_KEYS = [
     "keyDelay",
     "autoLoopDelay",
     "autoLoopHold",
+    "oasModeEnabled",
     "siteRules",
     "validationVocabulary",
     "validationFilterEnabled",

--- a/QA Assist v1.1/log.html
+++ b/QA Assist v1.1/log.html
@@ -34,7 +34,6 @@
                         <th>Truck</th>
                         <th>Timestamp</th>
                         <th>Site</th>
-                        <th>Operator</th>
                         <th>Notes</th>
                         <th>Actions</th>
                     </tr>
@@ -56,7 +55,6 @@
             <table>
                 <thead>
                     <tr>
-                        <th>Operator</th>
                         <th>Event</th>
                         <th>Validation</th>
                         <th>Truck</th>

--- a/QA Assist v1.1/popup.html
+++ b/QA Assist v1.1/popup.html
@@ -77,6 +77,13 @@
                     <option value="2">2x</option>
                 </select>
             </label>
+            <div class="playback-controls">
+                <span class="playback-label">Universal Playback</span>
+                <div class="playback-buttons">
+                    <button type="button" id="pauseAll" class="mini-button" title="Pause all videos" aria-label="Pause all videos">⏸</button>
+                    <button type="button" id="playAll" class="mini-button" title="Play all videos" aria-label="Play all videos">▶</button>
+                </div>
+            </div>
         </section>
 
         <p id="lostMessage" class="status-note hidden">Required page elements not detected. Refresh the tab or force auto mode.</p>

--- a/QA Assist v1.1/popup.js
+++ b/QA Assist v1.1/popup.js
@@ -13,6 +13,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const removeEyeToggle = document.getElementById("removeEyeToggle");
     const instaLogButton = document.getElementById("instaLog");
     const universalSpeedSelect = document.getElementById("universalSpeedSelect");
+    const pauseAllButton = document.getElementById("pauseAll");
+    const playAllButton = document.getElementById("playAll");
     const lostMessage = document.getElementById("lostMessage");
     const forceAutoButton = document.getElementById("forceAuto");
     const openLogButton = document.getElementById("openLog");
@@ -156,6 +158,12 @@ document.addEventListener("DOMContentLoaded", () => {
         removeEyeToggle.disabled = !extensionActive;
         if (universalSpeedSelect) {
             universalSpeedSelect.disabled = !extensionActive;
+        }
+        if (pauseAllButton) {
+            pauseAllButton.disabled = !extensionActive;
+        }
+        if (playAllButton) {
+            playAllButton.disabled = !extensionActive;
         }
         if (dispatchInput) {
             dispatchInput.disabled = !extensionActive;
@@ -536,6 +544,22 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
 
+    function broadcastPlaybackCommand(action) {
+        if (!currentEnabled) {
+            return;
+        }
+        chrome.tabs.query({}, (tabs) => {
+            if (chrome.runtime.lastError || !Array.isArray(tabs)) {
+                return;
+            }
+            tabs.forEach((tab) => {
+                chrome.tabs.sendMessage(tab.id, { type: "qaAssist:playbackCommand", action }, () => {
+                    chrome.runtime.lastError;
+                });
+            });
+        });
+    }
+
     extensionToggle.addEventListener("change", () => {
         const desiredState = extensionToggle.checked;
         commitEnabledState(desiredState);
@@ -576,6 +600,18 @@ document.addEventListener("DOMContentLoaded", () => {
     if (universalSpeedSelect) {
         universalSpeedSelect.addEventListener("change", () => {
             commitUniversalSpeed(universalSpeedSelect.value);
+        });
+    }
+
+    if (pauseAllButton) {
+        pauseAllButton.addEventListener("click", () => {
+            broadcastPlaybackCommand("pause");
+        });
+    }
+
+    if (playAllButton) {
+        playAllButton.addEventListener("click", () => {
+            broadcastPlaybackCommand("play");
         });
     }
 

--- a/QA Assist v1.1/qa-control.html
+++ b/QA Assist v1.1/qa-control.html
@@ -47,13 +47,13 @@
 
         <section class="page-card" id="watchListCard">
             <div class="card-header">
-                <h2>Operator watch list</h2>
+                <h2>Truck watch list</h2>
                 <div class="card-controls">
                     <button class="collapse-toggle" type="button" aria-expanded="true" aria-label="Collapse section"></button>
                 </div>
             </div>
             <div class="card-body">
-                <p class="helper-text">Operators or trucks with three or more fatigue validations in the same window are flagged below.</p>
+                <p class="helper-text">Trucks with three or more fatigue validations in the same window are flagged below. Duplicate event records with identical timestamp, event, and validation are ignored for watch calculations.</p>
                 <div class="watch-columns">
                     <div class="watch-column">
                         <h3>3+ fatigue events within 1 hour</h3>
@@ -75,7 +75,7 @@
                 </div>
             </div>
             <div class="card-body">
-                <p class="helper-text">Highlights trucks or operators with repeated technical alerts inside the same hour window.</p>
+                <p class="helper-text">Highlights trucks with repeated technical alerts inside the same hour window.</p>
                 <div class="spotlight-sections">
                     <div class="spotlight-block">
                         <h3>Event type hotspots</h3>
@@ -116,7 +116,7 @@
                 </div>
             </div>
             <div class="card-body">
-                <p class="helper-text">Same-truck events generated less than two minutes apart.</p>
+                <p class="helper-text">Same-truck events with more than two events in a one-minute window.</p>
                 <div id="fluctuationContainer" class="fluctuation-list"></div>
             </div>
         </section>

--- a/QA Assist v1.1/settings.html
+++ b/QA Assist v1.1/settings.html
@@ -78,6 +78,25 @@
 
         <section class="page-card">
             <div class="card-header">
+                <h2>OAS Mode</h2>
+                <div class="card-controls">
+                    <button class="collapse-toggle" type="button" aria-expanded="true" aria-label="Collapse section"></button>
+                </div>
+            </div>
+            <div class="card-body">
+                <label class="toggle-row">
+                    <input id="oasModeToggle" type="checkbox"> <span>Enable OAS Mode</span>
+                </label>
+                <p class="helper-text">Use the right arrow for auto-advance when videos end.</p>
+                <label class="inline-input">
+                    Site health latency refresh every
+                    <input id="siteHealthCheckMinutes" type="number" min="1" value="10"> minutes
+                </label>
+            </div>
+        </section>
+
+        <section class="page-card">
+            <div class="card-header">
                 <h2>Anti lag</h2>
                 <div class="card-controls">
                     <button class="collapse-toggle" type="button" aria-expanded="true" aria-label="Collapse section"></button>

--- a/QA Assist v1.1/settings.js
+++ b/QA Assist v1.1/settings.js
@@ -31,9 +31,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const loopHoldInput = document.getElementById('loopHold');
     const loopResetContainer = document.getElementById('loopResetContainer');
     const loopHoldContainer = document.getElementById('loopHoldContainer');
+    const oasModeToggle = document.getElementById('oasModeToggle');
     const antiLagToggle = document.getElementById('antiLagToggle');
     const antiLagSeekInput = document.getElementById('antiLagSeek');
     const antiLagSeekContainer = document.getElementById('antiLagSeekContainer');
+    const siteHealthCheckMinutesInput = document.getElementById('siteHealthCheckMinutes');
     const saveBtn = document.getElementById('saveSettings');
     const siteRulesContainer = document.getElementById('siteRulesContainer');
     const addSiteRuleBtn = document.getElementById('addSiteRule');
@@ -285,6 +287,15 @@ document.addEventListener('DOMContentLoaded', () => {
         autoNextLabel.appendChild(autoNext);
         autoNextLabel.append(' Auto Press Next');
 
+        const oasMode = document.createElement('input');
+        oasMode.type = 'checkbox';
+        oasMode.className = 'oasMode';
+        oasMode.checked = rule?.oasModeEnabled || false;
+
+        const oasModeLabel = document.createElement('label');
+        oasModeLabel.appendChild(oasMode);
+        oasModeLabel.append(' OAS Mode');
+
         const removeEye = document.createElement('input');
         removeEye.type = 'checkbox';
         removeEye.className = 'removeEye';
@@ -368,6 +379,7 @@ document.addEventListener('DOMContentLoaded', () => {
             speedLabel,
             keyLabel,
             autoNextLabel,
+            oasModeLabel,
             removeEyeLabel,
             smartSkipLabel,
             keyDelayLabel,
@@ -512,11 +524,13 @@ document.addEventListener('DOMContentLoaded', () => {
             autoLoopEnabled: false,
             autoLoopDelay: 8,
             autoLoopHold: 5,
+            oasModeEnabled: false,
             siteRules: {},
             validationVocabulary: DEFAULT_VALIDATION_VOCABULARY,
             validationFilterEnabled: true,
             antiLagEnabled: false,
             antiLagSeekSeconds: DEFAULT_ANTI_LAG_SEEK,
+            siteHealthCheckMinutes: 10,
         },
         (data) => {
         const rules = data.customSpeedRules;
@@ -532,11 +546,17 @@ document.addEventListener('DOMContentLoaded', () => {
         loopToggle.checked = data.autoLoopEnabled;
         loopResetInput.value = data.autoLoopDelay ?? 8;
         loopHoldInput.value = data.autoLoopHold ?? 5;
+        if (oasModeToggle) {
+            oasModeToggle.checked = data.oasModeEnabled ?? false;
+        }
         if (antiLagToggle) {
             antiLagToggle.checked = data.antiLagEnabled ?? false;
         }
         if (antiLagSeekInput) {
             antiLagSeekInput.value = data.antiLagSeekSeconds ?? DEFAULT_ANTI_LAG_SEEK;
+        }
+        if (siteHealthCheckMinutesInput) {
+            siteHealthCheckMinutesInput.value = data.siteHealthCheckMinutes ?? 10;
         }
         Object.entries(data.siteRules).forEach(([url, cfg]) => {
             createSiteRuleRow(Object.assign({ url }, cfg));
@@ -571,7 +591,12 @@ document.addEventListener('DOMContentLoaded', () => {
         keyDelayInput.value = keyDelay;
 
         const enabled = smartSkipToggle.checked;
+        const siteHealthCheckMinutes = Math.max(1, parseFloat(siteHealthCheckMinutesInput?.value) || 10);
+        if (siteHealthCheckMinutesInput) {
+            siteHealthCheckMinutesInput.value = siteHealthCheckMinutes;
+        }
         const autoLoopEnabled = loopToggle.checked;
+        const oasModeEnabled = oasModeToggle ? oasModeToggle.checked : false;
         const antiLagEnabled = antiLagToggle ? antiLagToggle.checked : false;
         const rawAntiLag = parseFloat(antiLagSeekInput?.value);
         const antiLagSeekSeconds = Number.isFinite(rawAntiLag)
@@ -614,6 +639,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 speed: div.querySelector('.speed').value,
                 pressKey: div.querySelector('.key').value,
                 autoPressNext: div.querySelector('.autoNext').checked,
+                oasModeEnabled: div.querySelector('.oasMode').checked,
                 removeEyeTracker: div.querySelector('.removeEye').checked,
                 smartSkipEnabled: div.querySelector('.smartSkip').checked,
                 skipDelay: parseFloat(div.querySelector('.skipDelay').value) || 0,
@@ -634,11 +660,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 autoLoopEnabled,
                 autoLoopDelay: parseFloat(loopResetInput.value) || 8,
                 autoLoopHold: parseFloat(loopHoldInput.value) || 5,
+                oasModeEnabled,
                 siteRules,
                 validationVocabulary: sanitizedVocabulary,
                 validationFilterEnabled,
                 antiLagEnabled,
                 antiLagSeekSeconds,
+                siteHealthCheckMinutes,
             },
             () => {
                 chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
@@ -651,11 +679,13 @@ document.addEventListener('DOMContentLoaded', () => {
                             autoLoopEnabled,
                             autoLoopDelay: parseFloat(loopResetInput.value) || 8,
                             autoLoopHold: parseFloat(loopHoldInput.value) || 5,
+                            oasModeEnabled,
                             siteRules,
                             validationVocabulary: sanitizedVocabulary,
                             validationFilterEnabled,
                             antiLagEnabled,
                             antiLagSeekSeconds,
+                            siteHealthCheckMinutes,
                         });
                     }
                 });

--- a/QA Assist v1.1/styles.css
+++ b/QA Assist v1.1/styles.css
@@ -1747,6 +1747,61 @@ body.popup {
     background: rgba(255, 255, 255, 0.02);
 }
 
+.playback-controls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text);
+}
+
+.playback-label {
+    font-size: 11px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+
+.playback-buttons {
+    display: inline-flex;
+    gap: 6px;
+}
+
+.mini-button {
+    width: 28px;
+    height: 24px;
+    border-radius: 7px;
+    border: 1px solid var(--border);
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--text);
+    font-size: 12px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.mini-button:hover,
+.mini-button:focus-visible {
+    background: rgba(255, 255, 255, 0.14);
+    border-color: rgba(255, 255, 255, 0.3);
+    box-shadow: 0 10px 18px rgba(15, 23, 42, 0.35);
+}
+
+.mini-button:focus-visible {
+    outline: 2px solid rgba(76, 141, 255, 0.45);
+    outline-offset: 2px;
+}
+
+.mini-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    box-shadow: none;
+    transform: none;
+}
+
 .toggle-row {
     display: flex;
     align-items: center;


### PR DESCRIPTION
### Motivation
- Replace fragile array-based `chrome.storage.local.eventLogs` rewrites with per-record storage so event insertion is atomic and scalable and legacy large-array reads are avoided.
- Prevent repeated identical records from inflating fatigue / hotspot metrics by deduplicating analytics by exact timestamp/event/validation/truck signature.
- Surface per-site health/latency information and give operators the ability to edit/delete logs while removing operator names to focus on truck identity.

### Description
- Persist events as individual records in an IndexedDB database (`qaAssistEventLogs`, object store `eventLogs`) with indexes for `eventKey`, `timestampMs` and `siteName`; `content.js` now uses `findLogByEventKey` and `putEventLog` to insert events and avoid large array rewrites, and falls back to legacy storage when needed.
- Migrate the Event Log page to read from IndexedDB (`getAllEventLogsFromDb`) with a one-time fallback/migration from `chrome.storage.local.eventLogs`, and persist edits/deletes back via a DB replace operation (`replaceAllEventLogsInDb`).
- Introduce analytics dedupe for QA Control: build a duplicate key from `timestamp + eventType + validation + truck` and filter identical records before computing watchlists/spotlights/flu ct uation clusters; watch identity was switched to truck+site (operator names removed) and UI copy updated to be truck-focused.
- Add site health/latency polling and caching (`measureLatencyForHost`, `getSiteHealthStats`) with a configurable refresh cadence stored as `siteHealthCheckMinutes` in settings and exposed in the Site Stats cards (shows latency/status and a warning when <5 distinct days of data).
- Add UI and behavior changes: removed operator columns from `log.html`, added in-row `Edit` and `Delete` buttons (with confirmation) on log rows and bookmarks, added playback controls in the popup that broadcast `play`/`pause` across tabs, and wired `oasMode` through settings/storage to detection logic.
- Improve timestamp parsing to accept `MM/DD` dates and assume the current system year when the year is absent, and adjust fluctuation detection to a 1-minute window with a 3+ event threshold.

### Testing
- Static checks: `node --check content.js && node --check log.js && node --check qa-control.js && node --check settings.js` passed.
- Unit test: `npm test` (runs `tests/enabled-state-controller.test.js`) passed: "All enabled state controller tests passed".
- Manual/UX: served the UI via `python -m http.server 8000` and captured a Playwright screenshot of `qa-control.html` demonstrating site health and stats rendering (artifact produced), and exercised log edit/delete, migration fallback, and playback broadcast flows during development, all behaving as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69836c4cc3888325bafe5cb8341de84a)