### PR TITLE
Move event logging to IndexedDB, dedupe by event identity, remove operator names, add edit/delete UI

### DIFF
--- a/QA 2.1/background.js
+++ b/QA 2.1/background.js
@@ -53,6 +53,11 @@ const STORAGE_MIGRATION_KEYS = [
     "antiLagEnabled",
     "antiLagSeekSeconds",
 ];
+const ALERT_ALARM_NAME = "qaAssistAlertScan";
+const ALERT_SCAN_PERIOD_MINUTES = 1;
+const ALERT_WINDOW_MS = 60 * 60 * 1000;
+const ALERT_SPOTLIGHT_TERMS = ["searching face", "detection error", "false positive", "non event", "blocked", "unsafe", "dark glasses"];
+
 
 function updateBrowserActionIcon(isEnabled) {
     if (!actionApi || typeof actionApi.setIcon !== "function") {
@@ -124,14 +129,208 @@ chrome.runtime.onInstalled.addListener(() => {
     migrateSyncStorage();
     migrateDispatchName();
     initializeSiteDirectory();
-    chrome.storage.local.get({ pendingAlertCount: 0 }, (data) => setAlertBadge(Number(data.pendingAlertCount) || 0));
+    ensureAlertAlarm();
+    runAlertScan();
 });
 chrome.runtime.onStartup.addListener(() => {
     migrateSyncStorage();
     migrateDispatchName();
     initializeSiteDirectory();
-    chrome.storage.local.get({ pendingAlertCount: 0 }, (data) => setAlertBadge(Number(data.pendingAlertCount) || 0));
+    ensureAlertAlarm();
+    runAlertScan();
 });
+
+if (chrome.alarms && chrome.alarms.onAlarm) {
+    chrome.alarms.onAlarm.addListener((alarm) => {
+        if (alarm?.name === ALERT_ALARM_NAME) {
+            runAlertScan();
+        }
+    });
+}
+
+
+function ensureAlertAlarm() {
+    if (!chrome.alarms) {
+        return;
+    }
+    chrome.alarms.create(ALERT_ALARM_NAME, { periodInMinutes: ALERT_SCAN_PERIOD_MINUTES });
+}
+
+function isFatigueValidation(text) {
+    const value = String(text || "").trim().toLowerCase();
+    if (!value) {
+        return false;
+    }
+    return value.includes("fatigue") || /\b(low|moderate|critical)\b/.test(value);
+}
+
+function matchesSpotlight(text) {
+    const value = String(text || "").trim().toLowerCase();
+    if (!value) {
+        return false;
+    }
+    return ALERT_SPOTLIGHT_TERMS.some((term) => value.includes(term));
+}
+
+function getEventTime(log) {
+    if (!log) {
+        return NaN;
+    }
+    const candidates = [log.timestampMs, log.createdAt && Date.parse(log.createdAt), log.timestamp && Date.parse(log.timestamp)];
+    for (const candidate of candidates) {
+        const numeric = Number(candidate);
+        if (Number.isFinite(numeric)) {
+            return numeric;
+        }
+    }
+    return NaN;
+}
+
+function buildIdentity(log) {
+    const truck = String(log?.truckNumber || "").trim() || "Unknown truck";
+    const site = String(log?.siteName || "").trim() || "Unknown site";
+    return { key: `${truck.toLowerCase()}|${site.toLowerCase()}`, truck, site };
+}
+
+function findClusterWindows(events, windowSize, minCount) {
+    const timeline = (Array.isArray(events) ? events : [])
+        .map((event) => ({ event, time: getEventTime(event) }))
+        .filter((entry) => Number.isFinite(entry.time))
+        .sort((a, b) => a.time - b.time);
+
+    const clusters = [];
+    let start = 0;
+
+    while (start < timeline.length) {
+        let end = start;
+        while (end + 1 < timeline.length && timeline[end + 1].time - timeline[start].time <= windowSize) {
+            end += 1;
+        }
+
+        const windowEvents = timeline.slice(start, end + 1);
+        if (windowEvents.length >= minCount) {
+            clusters.push({
+                events: windowEvents.map((entry) => entry.event),
+                start: windowEvents[0].time,
+                end: windowEvents[windowEvents.length - 1].time,
+                count: windowEvents.length,
+            });
+        }
+        start = end + 1;
+    }
+
+    return clusters;
+}
+
+function collectAlertCandidates(logs) {
+    const byIdentity = new Map();
+    (Array.isArray(logs) ? logs : []).forEach((log) => {
+        const identity = buildIdentity(log);
+        if (!byIdentity.has(identity.key)) {
+            byIdentity.set(identity.key, { ...identity, events: [] });
+        }
+        byIdentity.get(identity.key).events.push(log);
+    });
+
+    const candidates = [];
+    byIdentity.forEach((group) => {
+        const fatigueEvents = group.events.filter((event) => isFatigueValidation(event.callValidationType || event.validationType));
+        findClusterWindows(fatigueEvents, ALERT_WINDOW_MS, 3).forEach((cluster) => {
+            candidates.push({
+                key: `watch|${group.key}|${cluster.start}|${cluster.end}|${cluster.count}`,
+                title: `Watch List: ${group.truck}`,
+                description: `${group.site} · ${cluster.count} fatigue alerts in 1 hour`,
+                createdAt: cluster.end,
+            });
+        });
+
+        const spotlightEvents = group.events.filter((event) => matchesSpotlight(event.eventType) || matchesSpotlight(event.callValidationType || event.validationType));
+        findClusterWindows(spotlightEvents, ALERT_WINDOW_MS, 3).forEach((cluster) => {
+            candidates.push({
+                key: `spotlight|${group.key}|${cluster.start}|${cluster.end}|${cluster.count}`,
+                title: `Technical Spotlight: ${group.truck}`,
+                description: `${group.site} · ${cluster.count} technical alerts in 1 hour`,
+                createdAt: cluster.end,
+            });
+        });
+    });
+
+    return candidates.sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
+}
+
+function createAlertRecord(alert) {
+    return {
+        id: `alert-${Date.now()}-${Math.floor(Math.random() * 100000)}`,
+        key: alert.key,
+        title: alert.title,
+        description: alert.description,
+        createdAt: Number.isFinite(alert.createdAt) ? alert.createdAt : Date.now(),
+        read: false,
+    };
+}
+
+function updateBadgeFromNotifications(notifications) {
+    const unreadCount = (Array.isArray(notifications) ? notifications : []).filter((entry) => !entry.read).length;
+    setAlertBadge(unreadCount);
+}
+
+function runAlertScan() {
+    if (typeof EventLogDB === "undefined" || typeof EventLogDB.getAll !== "function") {
+        return;
+    }
+
+    Promise.all([
+        EventLogDB.getAll(),
+        new Promise((resolve) => {
+            chrome.storage.local.get({
+                notificationsEnabled: true,
+                notificationMode: "windows",
+                alertNotifications: [],
+                seenAlertKeys: [],
+            }, resolve);
+        }),
+    ]).then(([rawLogs, settings]) => {
+        if (settings.notificationsEnabled === false) {
+            return;
+        }
+
+        const seenKeys = new Set(Array.isArray(settings.seenAlertKeys) ? settings.seenAlertKeys : []);
+        const existingNotifications = Array.isArray(settings.alertNotifications) ? settings.alertNotifications : [];
+
+        const normalized = (Array.isArray(rawLogs) ? rawLogs : []).map((log) => ({
+            ...log,
+            timestampMs: getEventTime(log),
+        })).filter((log) => Number.isFinite(log.timestampMs));
+
+        const deduped = new Map();
+        normalized.forEach((log) => {
+            const key = typeof EventLogDB.buildDuplicateKey === "function" ? EventLogDB.buildDuplicateKey(log) : `${log.id || ""}|${log.timestampMs}`;
+            deduped.set(key || `${log.id || ""}|${log.timestampMs}`, log);
+        });
+
+        const candidates = collectAlertCandidates(Array.from(deduped.values()));
+        const newAlerts = candidates.filter((alert) => alert.key && !seenKeys.has(alert.key));
+        if (!newAlerts.length) {
+            updateBadgeFromNotifications(existingNotifications);
+            return;
+        }
+
+        const records = newAlerts.map(createAlertRecord);
+        const notifications = records.concat(existingNotifications).slice(0, 300);
+        records.forEach((record) => seenKeys.add(record.key));
+        const seenAlertKeys = Array.from(seenKeys).slice(-800);
+
+        chrome.storage.local.set({ alertNotifications: notifications, seenAlertKeys }, () => {
+            updateBadgeFromNotifications(notifications);
+            const mode = settings.notificationMode === "extension" ? "extension" : "windows";
+            if (mode === "windows") {
+                records.forEach((record) => createWindowsNotification(record));
+            }
+        });
+    }).catch((error) => {
+        console.error("Alert scan failed", error);
+    });
+}
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (!message || typeof message !== "object") {
@@ -146,6 +345,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
         EventLogDB.upsert(message.event || null)
             .then((record) => {
+                runAlertScan();
                 sendResponse({ success: true, record: record || null });
             })
             .catch((error) => {
@@ -174,47 +374,69 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }
 
 
-    if (message.type === "qaControlAlerts") {
-        const incomingAlerts = Array.isArray(message.alerts) ? message.alerts : [];
-        chrome.storage.local.get({ notificationsEnabled: true, notificationMode: "windows", pendingAlertCount: 0, seenAlertKeys: [] }, (data) => {
-            if (data.notificationsEnabled === false || !incomingAlerts.length) {
-                sendResponse({ success: true, count: data.pendingAlertCount || 0 });
-                return;
-            }
+    if (message.type === "getAlertNotifications") {
+        chrome.storage.local.get({ alertNotifications: [] }, (data) => {
+            const notifications = Array.isArray(data.alertNotifications) ? data.alertNotifications : [];
+            updateBadgeFromNotifications(notifications);
+            sendResponse({ notifications });
+        });
+        return true;
+    }
 
-            const seenKeys = new Set(Array.isArray(data.seenAlertKeys) ? data.seenAlertKeys : []);
-            const newAlerts = incomingAlerts.filter((alert) => {
-                const key = typeof alert?.key === "string" ? alert.key : "";
-                return key && !seenKeys.has(key);
+    if (message.type === "markAllAlertsRead") {
+        chrome.storage.local.get({ alertNotifications: [] }, (data) => {
+            const notifications = (Array.isArray(data.alertNotifications) ? data.alertNotifications : []).map((entry) => ({ ...entry, read: true }));
+            chrome.storage.local.set({ alertNotifications: notifications }, () => {
+                updateBadgeFromNotifications(notifications);
+                sendResponse({ success: true });
             });
+        });
+        return true;
+    }
 
-            if (!newAlerts.length) {
-                sendResponse({ success: true, count: data.pendingAlertCount || 0, duplicate: true });
-                return;
-            }
-
-            newAlerts.forEach((alert) => seenKeys.add(alert.key));
-            const nextCount = (Number(data.pendingAlertCount) || 0) + newAlerts.length;
-            const seenAlertKeys = Array.from(seenKeys).slice(-500);
-            chrome.storage.local.set({ pendingAlertCount: nextCount, latestExtensionAlert: newAlerts[0]?.description || "", seenAlertKeys }, () => {
-                setAlertBadge(nextCount);
-                const mode = message.mode === "extension" ? "extension" : (data.notificationMode === "extension" ? "extension" : "windows");
-                if (mode === "windows") {
-                    newAlerts.forEach((alert) => createWindowsNotification(alert));
-                }
-                sendResponse({ success: true, count: nextCount, added: newAlerts.length });
+    if (message.type === "markAlertRead") {
+        const id = String(message.id || "");
+        chrome.storage.local.get({ alertNotifications: [] }, (data) => {
+            const notifications = (Array.isArray(data.alertNotifications) ? data.alertNotifications : []).map((entry) => entry.id === id ? { ...entry, read: true } : entry);
+            chrome.storage.local.set({ alertNotifications: notifications }, () => {
+                updateBadgeFromNotifications(notifications);
+                sendResponse({ success: true });
             });
+        });
+        return true;
+    }
+
+    if (message.type === "deleteAlert") {
+        const id = String(message.id || "");
+        chrome.storage.local.get({ alertNotifications: [] }, (data) => {
+            const notifications = (Array.isArray(data.alertNotifications) ? data.alertNotifications : []).filter((entry) => entry.id !== id);
+            chrome.storage.local.set({ alertNotifications: notifications }, () => {
+                updateBadgeFromNotifications(notifications);
+                sendResponse({ success: true });
+            });
+        });
+        return true;
+    }
+
+    if (message.type === "clearAlerts") {
+        chrome.storage.local.set({ alertNotifications: [], seenAlertKeys: [] }, () => {
+            updateBadgeFromNotifications([]);
+            sendResponse({ success: true });
         });
         return true;
     }
 
     if (message.type === "clearAlertBadge") {
-        chrome.storage.local.set({ pendingAlertCount: 0 }, () => {
-            setAlertBadge(0);
-            sendResponse({ success: true });
+        chrome.storage.local.get({ alertNotifications: [] }, (data) => {
+            const notifications = (Array.isArray(data.alertNotifications) ? data.alertNotifications : []).map((entry) => ({ ...entry, read: true }));
+            chrome.storage.local.set({ alertNotifications: notifications }, () => {
+                updateBadgeFromNotifications(notifications);
+                sendResponse({ success: true });
+            });
         });
         return true;
     }
+
     if (message.type === "setEnabledState") {
         if (enabledStateController) {
             enabledStateController
@@ -253,6 +475,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 chrome.storage.onChanged.addListener((changes, areaName) => {
     if (enabledStateController) {
         enabledStateController.handleStorageChange(changes, areaName);
+    }
+    if (areaName === "local" && changes.alertNotifications) {
+        const next = Array.isArray(changes.alertNotifications.newValue) ? changes.alertNotifications.newValue : [];
+        updateBadgeFromNotifications(next);
     }
 });
 

--- a/QA 2.1/card-collapse-state.js
+++ b/QA 2.1/card-collapse-state.js
@@ -1,0 +1,54 @@
+(function initCardCollapseNamespace(global) {
+    const STORAGE_KEY = "cardCollapseState";
+
+    function normalizeId(card, index) {
+        return card.dataset.collapseId || card.id || `card-${index}`;
+    }
+
+    function updateToggle(button, collapsed) {
+        if (!button) {
+            return;
+        }
+        button.textContent = collapsed ? "+" : "−";
+        button.setAttribute("aria-expanded", collapsed ? "false" : "true");
+        button.setAttribute("aria-label", collapsed ? "Expand section" : "Collapse section");
+    }
+
+    function initCardCollapseState(pageKey) {
+        const cards = Array.from(document.querySelectorAll(".page-card"));
+        if (!cards.length || !chrome?.storage?.local) {
+            return;
+        }
+
+        chrome.storage.local.get({ [STORAGE_KEY]: {} }, (data) => {
+            const allState = data[STORAGE_KEY] || {};
+            const pageState = allState[pageKey] || {};
+
+            cards.forEach((card, index) => {
+                const id = normalizeId(card, index);
+                const toggle = card.querySelector(".collapse-toggle");
+                if (!toggle) {
+                    return;
+                }
+
+                const shouldCollapse = Boolean(pageState[id]);
+                card.classList.toggle("collapsed", shouldCollapse);
+                updateToggle(toggle, shouldCollapse);
+
+                toggle.addEventListener("click", () => {
+                    const collapsed = card.classList.toggle("collapsed");
+                    updateToggle(toggle, collapsed);
+                    chrome.storage.local.get({ [STORAGE_KEY]: {} }, (stateData) => {
+                        const next = stateData[STORAGE_KEY] || {};
+                        const nextPage = { ...(next[pageKey] || {}) };
+                        nextPage[id] = collapsed;
+                        next[pageKey] = nextPage;
+                        chrome.storage.local.set({ [STORAGE_KEY]: next });
+                    });
+                });
+            });
+        });
+    }
+
+    global.CardCollapseState = { initCardCollapseState, updateToggle };
+})(typeof window !== "undefined" ? window : globalThis);

--- a/QA 2.1/event-log-db.js
+++ b/QA 2.1/event-log-db.js
@@ -98,7 +98,12 @@
         record.createdAtMs = Number.isFinite(createdAtMs) ? createdAtMs : Date.now();
         record.timestampMs = Number.isFinite(timestampMs) ? timestampMs : record.createdAtMs;
 
-        record.duplicateKey = buildDuplicateKey(record);
+        const duplicateKey = buildDuplicateKey(record);
+        if (duplicateKey) {
+            record.duplicateKey = duplicateKey;
+        } else if (Object.prototype.hasOwnProperty.call(record, "duplicateKey")) {
+            delete record.duplicateKey;
+        }
 
         if (!Array.isArray(record.callHistory)) {
             record.callHistory = [];

--- a/QA 2.1/event-log-db.js
+++ b/QA 2.1/event-log-db.js
@@ -1,0 +1,294 @@
+(function (globalScope) {
+    const DB_NAME = "qaAssistEventLogs";
+    const DB_VERSION = 1;
+    const STORE_NAME = "eventLogs";
+    const MIGRATION_FLAG = "qaEventLogsMigratedToIndexedDb";
+
+    let dbPromise = null;
+    let migrationPromise = null;
+
+    function safeText(value) {
+        if (value === null || value === undefined) {
+            return "";
+        }
+        return String(value).trim();
+    }
+
+    function normalizeKeyPart(value) {
+        return safeText(value).toLowerCase();
+    }
+
+    function parseTimestampMs(input) {
+        const raw = safeText(input);
+        if (!raw) {
+            return NaN;
+        }
+
+        const parsed = Date.parse(raw);
+        if (Number.isFinite(parsed)) {
+            return parsed;
+        }
+
+        return NaN;
+    }
+
+    function deriveEventDate(log) {
+        const explicitDate = safeText(log?.eventDate || log?.date);
+        if (explicitDate) {
+            return explicitDate;
+        }
+
+        const timestampMs = parseTimestampMs(log?.timestamp || log?.eventTimestamp || log?.eventTime);
+        if (Number.isFinite(timestampMs)) {
+            return new Date(timestampMs).toISOString().slice(0, 10);
+        }
+
+        const createdAtMs = parseTimestampMs(log?.createdAt);
+        if (Number.isFinite(createdAtMs)) {
+            return new Date(createdAtMs).toISOString().slice(0, 10);
+        }
+
+        return "";
+    }
+
+    function buildDuplicateKey(log) {
+        const eventType = normalizeKeyPart(log?.eventType);
+        const timestamp = normalizeKeyPart(log?.timestamp);
+        const eventDate = normalizeKeyPart(deriveEventDate(log));
+        const truckNumber = normalizeKeyPart(log?.truckNumber);
+        const siteName = normalizeKeyPart(log?.siteName || log?.siteMatchValue);
+
+        if (!eventType || !timestamp || !eventDate || !truckNumber || !siteName) {
+            return "";
+        }
+
+        return [eventType, timestamp, eventDate, truckNumber, siteName].join("|");
+    }
+
+    function generateId() {
+        if (typeof crypto !== "undefined" && crypto.randomUUID) {
+            return crypto.randomUUID();
+        }
+
+        return `event-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+    }
+
+    function normalizeLog(log) {
+        const record = { ...(log || {}) };
+
+        record.id = safeText(record.id) || generateId();
+        record.timestamp = safeText(record.timestamp);
+        record.eventType = safeText(record.eventType);
+        record.truckNumber = safeText(record.truckNumber);
+        record.operatorName = "";
+        record.siteName = safeText(record.siteName);
+        record.siteMatchValue = safeText(record.siteMatchValue);
+
+        if (!record.eventDate) {
+            record.eventDate = deriveEventDate(record);
+        } else {
+            record.eventDate = safeText(record.eventDate);
+        }
+
+        const timestampMs = parseTimestampMs(record.timestamp || record.eventTimestamp || record.eventTime);
+        const createdAtText = safeText(record.createdAt) || new Date().toISOString();
+        const createdAtMs = parseTimestampMs(createdAtText);
+
+        record.createdAt = createdAtText;
+        record.createdAtMs = Number.isFinite(createdAtMs) ? createdAtMs : Date.now();
+        record.timestampMs = Number.isFinite(timestampMs) ? timestampMs : record.createdAtMs;
+
+        record.duplicateKey = buildDuplicateKey(record);
+
+        if (!Array.isArray(record.callHistory)) {
+            record.callHistory = [];
+        }
+
+        return record;
+    }
+
+    function openDb() {
+        if (dbPromise) {
+            return dbPromise;
+        }
+
+        dbPromise = new Promise((resolve, reject) => {
+            const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+            request.onupgradeneeded = (event) => {
+                const db = event.target.result;
+                const store = db.objectStoreNames.contains(STORE_NAME)
+                    ? event.target.transaction.objectStore(STORE_NAME)
+                    : db.createObjectStore(STORE_NAME, { keyPath: "id" });
+
+                if (!store.indexNames.contains("byEventKey")) {
+                    store.createIndex("byEventKey", "eventKey", { unique: false });
+                }
+
+                if (!store.indexNames.contains("byTimestampMs")) {
+                    store.createIndex("byTimestampMs", "timestampMs", { unique: false });
+                }
+
+                if (!store.indexNames.contains("byDuplicateKey")) {
+                    store.createIndex("byDuplicateKey", "duplicateKey", { unique: true });
+                }
+            };
+
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error || new Error("Failed to open IndexedDB"));
+        });
+
+        return dbPromise;
+    }
+
+    function runTransaction(mode, callback) {
+        return openDb().then(
+            (db) =>
+                new Promise((resolve, reject) => {
+                    const tx = db.transaction(STORE_NAME, mode);
+                    const store = tx.objectStore(STORE_NAME);
+
+                    let result;
+                    try {
+                        result = callback(store, tx);
+                    } catch (error) {
+                        reject(error);
+                        return;
+                    }
+
+                    tx.oncomplete = () => resolve(result);
+                    tx.onerror = () => reject(tx.error || new Error("IndexedDB transaction failed"));
+                    tx.onabort = () => reject(tx.error || new Error("IndexedDB transaction aborted"));
+                }),
+        );
+    }
+
+    function requestToPromise(request) {
+        return new Promise((resolve, reject) => {
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error || new Error("IndexedDB request failed"));
+        });
+    }
+
+    function migrateFromStorage() {
+        if (migrationPromise) {
+            return migrationPromise;
+        }
+
+        migrationPromise = new Promise((resolve) => {
+            if (!chrome?.storage?.local) {
+                resolve();
+                return;
+            }
+
+            chrome.storage.local.get({ [MIGRATION_FLAG]: false, eventLogs: [] }, async (data) => {
+                const alreadyMigrated = Boolean(data[MIGRATION_FLAG]);
+                const legacyLogs = Array.isArray(data.eventLogs) ? data.eventLogs : [];
+
+                if (alreadyMigrated || !legacyLogs.length) {
+                    chrome.storage.local.set({ [MIGRATION_FLAG]: true }, () => resolve());
+                    return;
+                }
+
+                for (const log of legacyLogs) {
+                    try {
+                        await upsert(log);
+                    } catch (error) {
+                        console.warn("Failed to migrate legacy event log", error);
+                    }
+                }
+
+                chrome.storage.local.remove("eventLogs", () => {
+                    chrome.storage.local.set({ [MIGRATION_FLAG]: true }, () => resolve());
+                });
+            });
+        });
+
+        return migrationPromise;
+    }
+
+    async function upsert(log) {
+        const normalized = normalizeLog(log);
+
+        await migrateFromStorage();
+
+        return runTransaction("readwrite", (store) => {
+            const index = store.index("byDuplicateKey");
+            const getExistingRequest = normalized.duplicateKey ? index.get(normalized.duplicateKey) : null;
+
+            if (!getExistingRequest) {
+                store.put(normalized);
+                return normalized;
+            }
+
+            getExistingRequest.onsuccess = () => {
+                const existing = getExistingRequest.result;
+                if (!existing) {
+                    store.put(normalized);
+                    return;
+                }
+
+                const merged = {
+                    ...existing,
+                    ...normalized,
+                    id: existing.id,
+                    createdAt: existing.createdAt || normalized.createdAt,
+                    createdAtMs: Number.isFinite(existing.createdAtMs) ? existing.createdAtMs : normalized.createdAtMs,
+                    callHistory: Array.isArray(existing.callHistory) ? existing.callHistory : normalized.callHistory,
+                    bookmarked: Boolean(existing.bookmarked),
+                    comment: safeText(existing.comment),
+                };
+
+                store.put(normalizeLog(merged));
+            };
+
+            return normalized;
+        });
+    }
+
+    async function getAll() {
+        await migrateFromStorage();
+        return runTransaction("readonly", (store) => {
+            const request = store.getAll();
+            return requestToPromise(request);
+        }).then((result) => (Array.isArray(result) ? result.map(normalizeLog) : []));
+    }
+
+    async function remove(id) {
+        if (!id) {
+            return;
+        }
+        await migrateFromStorage();
+        await runTransaction("readwrite", (store) => {
+            store.delete(id);
+        });
+    }
+
+    async function clearAll() {
+        await migrateFromStorage();
+        await runTransaction("readwrite", (store) => {
+            store.clear();
+        });
+    }
+
+    async function replaceAll(logs) {
+        await migrateFromStorage();
+        await runTransaction("readwrite", (store) => {
+            store.clear();
+            (Array.isArray(logs) ? logs : []).forEach((log) => {
+                store.put(normalizeLog(log));
+            });
+        });
+    }
+
+    globalScope.EventLogDB = {
+        upsert,
+        getAll,
+        remove,
+        clearAll,
+        replaceAll,
+        normalizeLog,
+        buildDuplicateKey,
+        deriveEventDate,
+    };
+})(typeof window !== "undefined" ? window : globalThis);

--- a/QA 2.1/log.html
+++ b/QA 2.1/log.html
@@ -20,10 +20,10 @@
             </nav>
         </header>
 
-        <section class="page-card table-card" id="bookmarkSection">
+        <section class="page-card table-card" id="bookmarkSection" data-collapse-id="bookmarks">
             <div class="card-header">
                 <h2>Bookmarks</h2>
-                <span id="bookmarkCount" class="badge subtle">0 items</span>
+                <div class="card-controls"><span id="bookmarkCount" class="badge subtle">0 items</span><button class="collapse-toggle" type="button" aria-expanded="true" aria-label="Collapse section"></button></div>
             </div>
             <p class="helper-text">Bookmarked clips stay pinned for quick follow up and call prep.</p>
             <table>
@@ -43,10 +43,10 @@
             </table>
         </section>
 
-        <section class="page-card table-card">
+        <section class="page-card table-card" data-collapse-id="recentEvents">
             <div class="card-header">
                 <h2>Recent events</h2>
-                <span id="eventCount" class="badge subtle">0 items</span>
+                <div class="card-controls"><span id="eventCount" class="badge subtle">0 items</span><button class="collapse-toggle" type="button" aria-expanded="true" aria-label="Collapse section"></button></div>
             </div>
             <div class="controls">
                 <input type="text" id="filterInput" placeholder="Search by event, validation, truck, timestamp, site, or URL...">
@@ -188,6 +188,7 @@
         </div>
     </div>
 
+    <script src="card-collapse-state.js"></script>
     <script src="event-log-db.js"></script>
     <script src="log.js"></script>
 </body>

--- a/QA 2.1/log.html
+++ b/QA 2.1/log.html
@@ -34,7 +34,7 @@
                         <th>Truck</th>
                         <th>Timestamp</th>
                         <th>Site</th>
-                        <th>Operator</th>
+                        <th>Manage</th>
                         <th>Notes</th>
                         <th>Actions</th>
                     </tr>
@@ -56,7 +56,7 @@
             <table>
                 <thead>
                     <tr>
-                        <th>Operator</th>
+                        <th>Manage</th>
                         <th>Event</th>
                         <th>Validation</th>
                         <th>Truck</th>
@@ -154,6 +154,41 @@
 
     <div class="toast" id="logToast" role="status" aria-live="polite"></div>
 
+    <div class="modal" id="editLogModal" aria-hidden="true">
+        <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="editLogTitle">
+            <button class="close-modal" id="closeEditLogModal" title="Close">×</button>
+            <h2 id="editLogTitle">Edit event log</h2>
+            <p class="subtitle">Update event details before saving.</p>
+            <div class="form-grid">
+                <div class="form-group">
+                    <label for="editTruckNumber">Truck number</label>
+                    <input type="text" id="editTruckNumber" placeholder="Truck number">
+                </div>
+                <div class="form-group">
+                    <label for="editEventType">Event type</label>
+                    <input type="text" id="editEventType" placeholder="Event type">
+                </div>
+                <div class="form-group">
+                    <label for="editValidationType">Validation</label>
+                    <input type="text" id="editValidationType" placeholder="Validation type">
+                </div>
+                <div class="form-group">
+                    <label for="editTimestamp">Timestamp</label>
+                    <input type="text" id="editTimestamp" placeholder="Timestamp">
+                </div>
+                <div class="form-group">
+                    <label for="editSiteName">Site</label>
+                    <input type="text" id="editSiteName" placeholder="Site name">
+                </div>
+            </div>
+            <div class="modal-actions">
+                <button type="button" id="cancelEditLog" class="ghost">Cancel</button>
+                <button type="button" id="saveEditLog" class="primary">Save changes</button>
+            </div>
+        </div>
+    </div>
+
+    <script src="event-log-db.js"></script>
     <script src="log.js"></script>
 </body>
 </html>

--- a/QA 2.1/log.js
+++ b/QA 2.1/log.js
@@ -1,6 +1,7 @@
 // Enhanced log.js for QA Assist
 
 document.addEventListener("DOMContentLoaded", () => {
+    CardCollapseState?.initCardCollapseState?.("eventLog");
     const logTableBody = document.getElementById("logTableBody");
     const bookmarkBody = document.getElementById("bookmarkBody");
     const clearLogsButton = document.getElementById("clearLogs");

--- a/QA 2.1/manifest.json
+++ b/QA 2.1/manifest.json
@@ -12,7 +12,8 @@
     "permissions": [
         "tabs",
         "storage",
-        "activeTab"
+        "activeTab",
+        "notifications"
     ],
     "host_permissions": [
         "*://*/*"

--- a/QA 2.1/manifest.json
+++ b/QA 2.1/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "QA Assist",
-    "version": "1.456",
+    "version": "2.7",
     "description": "A tool to enhance QA workflows with automation and logging.",
     "author": "Abel Orta",
     "icons": {
@@ -9,15 +9,26 @@
         "48": "icon.png",
         "128": "icon.png"
     },
-    "permissions": ["tabs", "storage", "activeTab"],
-    "host_permissions": ["*://*/*"],
+    "permissions": [
+        "tabs",
+        "storage",
+        "activeTab"
+    ],
+    "host_permissions": [
+        "*://*/*"
+    ],
     "background": {
         "service_worker": "background.js"
     },
     "content_scripts": [
         {
-            "matches": ["*://*/*"],
-            "js": ["event-log-db.js", "content.js"]
+            "matches": [
+                "*://*/*"
+            ],
+            "js": [
+                "event-log-db.js",
+                "content.js"
+            ]
         }
     ],
     "action": {

--- a/QA 2.1/manifest.json
+++ b/QA 2.1/manifest.json
@@ -13,7 +13,8 @@
         "tabs",
         "storage",
         "activeTab",
-        "notifications"
+        "notifications",
+        "alarms"
     ],
     "host_permissions": [
         "*://*/*"

--- a/QA 2.1/manifest.json
+++ b/QA 2.1/manifest.json
@@ -17,7 +17,7 @@
     "content_scripts": [
         {
             "matches": ["*://*/*"],
-            "js": ["content.js"]
+            "js": ["event-log-db.js", "content.js"]
         }
     ],
     "action": {

--- a/QA 2.1/qa-control.html
+++ b/QA 2.1/qa-control.html
@@ -53,14 +53,18 @@
                 </div>
             </div>
             <div class="card-body">
-                <p class="helper-text">Trucks with three or more fatigue validations in the same window are flagged below. Duplicates are ignored for trend calculations.</p>
+                <p class="helper-text">Trucks with 3+ fatigue alerts inside a rolling one-hour window. Groups include every alert in that hour and are shown as separate clusters.</p>
+                <div class="section-range-controls">
+                    <label>From <input type="datetime-local" id="watchRangeStart"></label>
+                    <label>To <input type="datetime-local" id="watchRangeEnd"></label>
+                </div>
                 <div class="watch-columns">
                     <div class="watch-column">
                         <h3>3+ fatigue events within 1 hour</h3>
                         <div id="watchListOneHour" class="watch-list"></div>
                     </div>
                     <div class="watch-column">
-                        <h3>3+ fatigue events within 2 hours</h3>
+                        <h3>3+ fatigue events within 2 hours (cluster view)</h3>
                         <div id="watchListTwoHour" class="watch-list"></div>
                     </div>
                 </div>
@@ -75,7 +79,11 @@
                 </div>
             </div>
             <div class="card-body">
-                <p class="helper-text">Highlights trucks with repeated technical alerts inside the same hour window. Duplicate rows are ignored.</p>
+                <p class="helper-text">Highlights trucks with repeated technical alerts in one-hour clusters (minimum 5 alerts). Duplicate rows are ignored.</p>
+                <div class="section-range-controls">
+                    <label>From <input type="datetime-local" id="spotlightRangeStart"></label>
+                    <label>To <input type="datetime-local" id="spotlightRangeEnd"></label>
+                </div>
                 <div class="spotlight-sections">
                     <div class="spotlight-block">
                         <h3>Event type hotspots</h3>

--- a/QA 2.1/qa-control.html
+++ b/QA 2.1/qa-control.html
@@ -31,7 +31,7 @@
             </div>
         </header>
 
-        <section class="page-card" id="siteStatsCard">
+        <section class="page-card" id="siteStatsCard" data-collapse-id="siteStats">
             <div class="card-header">
                 <h2>Site stats</h2>
                 <div class="card-controls">
@@ -45,7 +45,7 @@
             </div>
         </section>
 
-        <section class="page-card" id="watchListCard">
+        <section class="page-card" id="watchListCard" data-collapse-id="watchList">
             <div class="card-header">
                 <h2>Truck watch list</h2>
                 <div class="card-controls">
@@ -76,7 +76,7 @@
             </div>
         </section>
 
-        <section class="page-card" id="spotlightsCard">
+        <section class="page-card" id="spotlightsCard" data-collapse-id="spotlights">
             <div class="card-header">
                 <h2>Technical spotlights</h2>
                 <div class="card-controls">
@@ -125,7 +125,7 @@
             </div>
         </section>
 
-        <section class="page-card" id="dataCenterCard">
+        <section class="page-card" id="dataCenterCard" data-collapse-id="dataCenter">
             <div class="card-header">
                 <h2>Data Center</h2>
                 <div class="card-controls">
@@ -161,7 +161,7 @@
             </div>
         </section>
 
-        <section class="page-card" id="fluctuationCard">
+        <section class="page-card" id="fluctuationCard" data-collapse-id="fluctuations">
             <div class="card-header">
                 <h2>Event fluctuations</h2>
                 <div class="card-controls">
@@ -178,6 +178,16 @@
 
     <div class="toast" id="controlToast" role="status" aria-live="polite"></div>
 
+    <div class="modal" id="dataCenterModal" aria-hidden="true">
+        <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="dataCenterModalTitle">
+            <button class="close-modal" id="closeDataCenterModal" title="Close">×</button>
+            <h2 id="dataCenterModalTitle">Data Center events</h2>
+            <div id="dataCenterModalMeta" class="subtitle"></div>
+            <ul id="dataCenterModalList" class="spotlight-events"></ul>
+        </div>
+    </div>
+
+    <script src="card-collapse-state.js"></script>
     <script src="event-log-db.js"></script>
     <script src="qa-control.js"></script>
 </body>

--- a/QA 2.1/qa-control.html
+++ b/QA 2.1/qa-control.html
@@ -57,6 +57,11 @@
                 <div class="section-range-controls">
                     <label>From <input type="datetime-local" id="watchRangeStart"></label>
                     <label>To <input type="datetime-local" id="watchRangeEnd"></label>
+                    <label>Keyword <input type="search" id="watchKeywordSearch" placeholder="Search truck, site, event, validation"></label>
+                    <div class="filter-actions">
+                        <button id="saveWatchFilters" class="secondary" type="button">Save</button>
+                        <button id="clearWatchFilters" class="secondary" type="button">Clear</button>
+                    </div>
                 </div>
                 <div class="watch-columns">
                     <div class="watch-column">
@@ -83,6 +88,11 @@
                 <div class="section-range-controls">
                     <label>From <input type="datetime-local" id="spotlightRangeStart"></label>
                     <label>To <input type="datetime-local" id="spotlightRangeEnd"></label>
+                    <label>Keyword <input type="search" id="spotlightKeywordSearch" placeholder="Search truck, site, event, validation"></label>
+                    <div class="filter-actions">
+                        <button id="saveSpotlightFilters" class="secondary" type="button">Save</button>
+                        <button id="clearSpotlightFilters" class="secondary" type="button">Clear</button>
+                    </div>
                 </div>
                 <div class="spotlight-sections">
                     <div class="spotlight-block">
@@ -112,6 +122,42 @@
                         </div>
                     </div>
                 </div>
+            </div>
+        </section>
+
+        <section class="page-card" id="dataCenterCard">
+            <div class="card-header">
+                <h2>Data Center</h2>
+                <div class="card-controls">
+                    <button class="collapse-toggle" type="button" aria-expanded="true" aria-label="Collapse section"></button>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="section-range-controls">
+                    <label>From <input type="datetime-local" id="dataCenterRangeStart"></label>
+                    <label>To <input type="datetime-local" id="dataCenterRangeEnd"></label>
+                    <label>Search #
+                        <select id="dataCenterFilter"></select>
+                    </label>
+                    <label>Group by
+                        <select id="dataCenterGroupBy">
+                            <option value="truck">Truck #</option>
+                            <option value="site">Site</option>
+                        </select>
+                    </label>
+                    <label>Keyword <input type="search" id="dataCenterKeywordSearch" placeholder="Search keyword"></label>
+                    <label>Sort
+                        <select id="dataCenterSortDirection">
+                            <option value="desc">Highest first</option>
+                            <option value="asc">Lowest first</option>
+                        </select>
+                    </label>
+                    <div class="filter-actions">
+                        <button id="saveDataCenterFilters" class="secondary" type="button">Save</button>
+                        <button id="clearDataCenterFilters" class="secondary" type="button">Clear</button>
+                    </div>
+                </div>
+                <div id="dataCenterContainer" class="data-center-list"></div>
             </div>
         </section>
 

--- a/QA 2.1/qa-control.html
+++ b/QA 2.1/qa-control.html
@@ -47,13 +47,13 @@
 
         <section class="page-card" id="watchListCard">
             <div class="card-header">
-                <h2>Operator watch list</h2>
+                <h2>Truck watch list</h2>
                 <div class="card-controls">
                     <button class="collapse-toggle" type="button" aria-expanded="true" aria-label="Collapse section"></button>
                 </div>
             </div>
             <div class="card-body">
-                <p class="helper-text">Operators or trucks with three or more fatigue validations in the same window are flagged below.</p>
+                <p class="helper-text">Trucks with three or more fatigue validations in the same window are flagged below. Duplicates are ignored for trend calculations.</p>
                 <div class="watch-columns">
                     <div class="watch-column">
                         <h3>3+ fatigue events within 1 hour</h3>
@@ -75,7 +75,7 @@
                 </div>
             </div>
             <div class="card-body">
-                <p class="helper-text">Highlights trucks or operators with repeated technical alerts inside the same hour window.</p>
+                <p class="helper-text">Highlights trucks with repeated technical alerts inside the same hour window. Duplicate rows are ignored.</p>
                 <div class="spotlight-sections">
                     <div class="spotlight-block">
                         <h3>Event type hotspots</h3>
@@ -124,6 +124,7 @@
 
     <div class="toast" id="controlToast" role="status" aria-live="polite"></div>
 
+    <script src="event-log-db.js"></script>
     <script src="qa-control.js"></script>
 </body>
 </html>

--- a/QA 2.1/qa-control.html
+++ b/QA 2.1/qa-control.html
@@ -31,6 +31,27 @@
             </div>
         </header>
 
+
+        <section class="page-card" id="notificationHubCard" data-collapse-id="notificationHub">
+            <div class="card-header">
+                <h2>Notification Hub</h2>
+                <div class="card-controls">
+                    <span id="notificationHubUnread" class="badge subtle">0 unread</span>
+                    <button id="markAllNotificationsRead" class="secondary" type="button">Mark all as read</button>
+                    <button id="clearAllNotifications" class="ghost" type="button">Clear all</button>
+                    <button class="collapse-toggle" type="button" aria-expanded="true" aria-label="Collapse section"></button>
+                </div>
+            </div>
+            <div class="card-body">
+                <div id="notificationHubList" class="notification-list"></div>
+                <div class="notification-pagination">
+                    <button id="notificationPrevPage" class="secondary" type="button">◀</button>
+                    <span id="notificationPageLabel">Page 1</span>
+                    <button id="notificationNextPage" class="secondary" type="button">▶</button>
+                </div>
+            </div>
+        </section>
+
         <section class="page-card" id="siteStatsCard" data-collapse-id="siteStats">
             <div class="card-header">
                 <h2>Site stats</h2>

--- a/QA 2.1/settings.html
+++ b/QA 2.1/settings.html
@@ -198,6 +198,24 @@
                     <input id="notificationVolume" type="range" min="0" max="1" step="0.05" value="0.25">
                     <span id="notificationVolumeLabel">25%</span>
                 </label>
+                <div class="grid two">
+                    <label class="toggle-row inline-toggle">
+                        <input id="watchListNotificationsEnabled" type="checkbox"> <span>Truck Watch List notifications</span>
+                    </label>
+                    <label class="toggle-row inline-toggle">
+                        <input id="spotlightNotificationsEnabled" type="checkbox"> <span>Technical Spotlight notifications</span>
+                    </label>
+                </div>
+                <div class="grid two">
+                    <label class="inline-input">
+                        New events needed for follow-up alert
+                        <input id="notificationIncrementThreshold" type="number" min="1" max="20" value="3">
+                    </label>
+                    <label class="inline-input">
+                        Wait before follow-up alert (minutes)
+                        <input id="notificationRepeatWindowMinutes" type="number" min="1" max="30" value="2">
+                    </label>
+                </div>
             </div>
         </section>
 

--- a/QA 2.1/settings.html
+++ b/QA 2.1/settings.html
@@ -128,6 +128,20 @@
 
         <section class="page-card">
             <div class="card-header">
+                <h2>Data Keywords</h2>
+                <div class="card-controls">
+                    <button class="collapse-toggle" type="button" aria-expanded="true" aria-label="Collapse section"></button>
+                </div>
+            </div>
+            <div class="card-body">
+                <p class="helper-text">Configure event-type and validation-type keyword aliases used by QA Control sections.</p>
+                <div id="dataKeywordList" class="validation-list"></div>
+                <button id="addDataKeyword" type="button" class="secondary">Add data keyword label</button>
+            </div>
+        </section>
+
+        <section class="page-card">
+            <div class="card-header">
                 <h2>Buffer between videos</h2>
                 <div class="card-controls">
                     <button class="collapse-toggle" type="button" aria-expanded="true" aria-label="Collapse section"></button>

--- a/QA 2.1/settings.html
+++ b/QA 2.1/settings.html
@@ -20,7 +20,7 @@
             </nav>
         </header>
 
-        <section class="page-card">
+        <section class="page-card" data-collapse-id="customSpeed">
             <div class="card-header">
                 <h2>Custom speed</h2>
                 <div class="card-controls">
@@ -34,7 +34,7 @@
             </div>
         </section>
 
-        <section class="page-card">
+        <section class="page-card" data-collapse-id="smartSkip">
             <div class="card-header">
                 <h2>Smart skip</h2>
                 <div class="card-controls">
@@ -52,7 +52,7 @@
             </div>
         </section>
 
-        <section class="page-card">
+        <section class="page-card" data-collapse-id="autoLoop">
             <div class="card-header">
                 <h2>Auto loop</h2>
                 <div class="card-controls">
@@ -76,7 +76,7 @@
             </div>
         </section>
 
-        <section class="page-card">
+        <section class="page-card" data-collapse-id="oasMode">
             <div class="card-header">
                 <h2>OAS Mode</h2>
                 <div class="card-controls">
@@ -91,7 +91,7 @@
             </div>
         </section>
 
-        <section class="page-card">
+        <section class="page-card" data-collapse-id="antiLag">
             <div class="card-header">
                 <h2>Anti lag</h2>
                 <div class="card-controls">
@@ -109,7 +109,7 @@
             </div>
         </section>
 
-        <section class="page-card">
+        <section class="page-card" data-collapse-id="validationFilter">
             <div class="card-header">
                 <h2>Validation filter</h2>
                 <div class="card-controls">
@@ -126,7 +126,7 @@
             </div>
         </section>
 
-        <section class="page-card">
+        <section class="page-card" data-collapse-id="dataKeywords">
             <div class="card-header">
                 <h2>Data Keywords</h2>
                 <div class="card-controls">
@@ -140,7 +140,7 @@
             </div>
         </section>
 
-        <section class="page-card">
+        <section class="page-card" data-collapse-id="bufferBetweenVideos">
             <div class="card-header">
                 <h2>Buffer between videos</h2>
                 <div class="card-controls">
@@ -155,7 +155,7 @@
             </div>
         </section>
 
-        <section class="page-card">
+        <section class="page-card" data-collapse-id="siteOverrides">
             <div class="card-header">
                 <h2>Site overrides</h2>
                 <div class="card-controls">
@@ -166,6 +166,38 @@
             <div class="card-body">
                 <p class="helper-text">Create domain-specific automation profiles. Overrides apply automatically when the active tab matches the configured pattern.</p>
                 <div id="siteRulesContainer" class="stack"></div>
+            </div>
+        </section>
+
+
+        <section class="page-card" data-collapse-id="notifications">
+            <div class="card-header">
+                <h2>Notifications</h2>
+                <div class="card-controls">
+                    <button class="collapse-toggle" type="button" aria-expanded="true" aria-label="Collapse section"></button>
+                </div>
+            </div>
+            <div class="card-body">
+                <label class="toggle-row">
+                    <input id="notificationsEnabled" type="checkbox"> <span>Enable alert notifications</span>
+                </label>
+                <div class="grid two">
+                    <label class="inline-input">
+                        Delivery mode
+                        <select id="notificationMode">
+                            <option value="windows">Windows notification</option>
+                            <option value="extension">Extension popup</option>
+                        </select>
+                    </label>
+                    <label class="toggle-row inline-toggle">
+                        <input id="notificationSoundEnabled" type="checkbox"> <span>Play notification sound</span>
+                    </label>
+                </div>
+                <label class="inline-input">
+                    Volume
+                    <input id="notificationVolume" type="range" min="0" max="1" step="0.05" value="0.25">
+                    <span id="notificationVolumeLabel">25%</span>
+                </label>
             </div>
         </section>
 
@@ -187,6 +219,7 @@
         </div>
     </div>
 
+    <script src="card-collapse-state.js"></script>
     <script src="settings.js"></script>
 </body>
 </html>

--- a/QA 2.1/settings.js
+++ b/QA 2.1/settings.js
@@ -61,6 +61,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const notificationSoundEnabledInput = document.getElementById('notificationSoundEnabled');
     const notificationVolumeInput = document.getElementById('notificationVolume');
     const notificationVolumeLabel = document.getElementById('notificationVolumeLabel');
+    const watchListNotificationsEnabledInput = document.getElementById('watchListNotificationsEnabled');
+    const spotlightNotificationsEnabledInput = document.getElementById('spotlightNotificationsEnabled');
+    const notificationIncrementThresholdInput = document.getElementById('notificationIncrementThreshold');
+    const notificationRepeatWindowMinutesInput = document.getElementById('notificationRepeatWindowMinutes');
     const siteRulesContainer = document.getElementById('siteRulesContainer');
     const addSiteRuleBtn = document.getElementById('addSiteRule');
     const toast = document.getElementById('settingsToast');
@@ -641,6 +645,10 @@ document.addEventListener('DOMContentLoaded', () => {
             notificationMode: 'windows',
             notificationSoundEnabled: true,
             notificationVolume: 0.25,
+            watchListNotificationsEnabled: true,
+            spotlightNotificationsEnabled: true,
+            notificationIncrementThreshold: 3,
+            notificationRepeatWindowMinutes: 2,
         },
         (data) => {
         const rules = data.customSpeedRules;
@@ -684,6 +692,10 @@ document.addEventListener('DOMContentLoaded', () => {
         if (notificationSoundEnabledInput) notificationSoundEnabledInput.checked = data.notificationSoundEnabled ?? true;
         if (notificationVolumeInput) notificationVolumeInput.value = Number.isFinite(data.notificationVolume) ? data.notificationVolume : 0.25;
         if (notificationVolumeLabel && notificationVolumeInput) notificationVolumeLabel.textContent = `${Math.round(Number(notificationVolumeInput.value) * 100)}%`;
+        if (watchListNotificationsEnabledInput) watchListNotificationsEnabledInput.checked = data.watchListNotificationsEnabled !== false;
+        if (spotlightNotificationsEnabledInput) spotlightNotificationsEnabledInput.checked = data.spotlightNotificationsEnabled !== false;
+        if (notificationIncrementThresholdInput) notificationIncrementThresholdInput.value = Number.isFinite(data.notificationIncrementThreshold) ? Math.max(1, Number(data.notificationIncrementThreshold)) : 3;
+        if (notificationRepeatWindowMinutesInput) notificationRepeatWindowMinutesInput.value = Number.isFinite(data.notificationRepeatWindowMinutes) ? Math.max(1, Number(data.notificationRepeatWindowMinutes)) : 2;
         updateSkipEnabled();
         updateLoopEnabled();
         updateValidationEnabled();
@@ -766,6 +778,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const notificationMode = notificationModeInput?.value === 'extension' ? 'extension' : 'windows';
         const notificationSoundEnabled = notificationSoundEnabledInput ? notificationSoundEnabledInput.checked : true;
         const notificationVolume = Math.max(0, Math.min(1, Number(notificationVolumeInput?.value ?? 0.25) || 0));
+        const watchListNotificationsEnabled = watchListNotificationsEnabledInput ? watchListNotificationsEnabledInput.checked : true;
+        const spotlightNotificationsEnabled = spotlightNotificationsEnabledInput ? spotlightNotificationsEnabledInput.checked : true;
+        const notificationIncrementThreshold = Math.max(1, Math.min(20, Number(notificationIncrementThresholdInput?.value ?? 3) || 3));
+        const notificationRepeatWindowMinutes = Math.max(1, Math.min(30, Number(notificationRepeatWindowMinutesInput?.value ?? 2) || 2));
 
         const siteRules = {};
         siteRulesContainer.querySelectorAll('.site-rule').forEach(div => {
@@ -808,6 +824,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 notificationMode,
                 notificationSoundEnabled,
                 notificationVolume,
+                watchListNotificationsEnabled,
+                spotlightNotificationsEnabled,
+                notificationIncrementThreshold,
+                notificationRepeatWindowMinutes,
             },
             () => {
                 chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
@@ -831,6 +851,10 @@ document.addEventListener('DOMContentLoaded', () => {
                             notificationMode,
                             notificationSoundEnabled,
                             notificationVolume,
+                            watchListNotificationsEnabled,
+                            spotlightNotificationsEnabled,
+                            notificationIncrementThreshold,
+                            notificationRepeatWindowMinutes,
                         });
                     }
                 });

--- a/QA 2.1/site-info.html
+++ b/QA 2.1/site-info.html
@@ -20,10 +20,10 @@
             </nav>
         </header>
 
-        <section class="page-card table-card">
+        <section class="page-card table-card" data-collapse-id="savedSites">
             <div class="card-header">
                 <h2>Saved sites</h2>
-                <span class="badge subtle" id="siteCount">0 sites</span>
+                <div class="card-controls"><span class="badge subtle" id="siteCount">0 sites</span><button class="collapse-toggle" type="button" aria-expanded="true" aria-label="Collapse section"></button></div>
             </div>
             <table>
                 <thead>
@@ -39,9 +39,10 @@
             <p class="helper-text">Sites are sorted alphabetically for faster lookups during calls.</p>
         </section>
 
-        <section class="page-card">
+        <section class="page-card" data-collapse-id="addSite">
             <div class="card-header">
                 <h2>Add site</h2>
+                <div class="card-controls"><button class="collapse-toggle" type="button" aria-expanded="true" aria-label="Collapse section"></button></div>
             </div>
             <div class="site-form">
                 <div class="form-grid">
@@ -68,6 +69,7 @@
     <button class="primary floating-save" id="addSite" type="button">Add site</button>
     <div class="toast" id="toast"></div>
 
+    <script src="card-collapse-state.js"></script>
     <script src="site-info.js"></script>
 </body>
 </html>

--- a/QA 2.1/site-info.js
+++ b/QA 2.1/site-info.js
@@ -1,4 +1,5 @@
 document.addEventListener("DOMContentLoaded", () => {
+    CardCollapseState?.initCardCollapseState?.("siteInfo");
     const siteTableBody = document.getElementById("siteTableBody");
     const siteCount = document.getElementById("siteCount");
     const siteNameInput = document.getElementById("siteNameInput");

--- a/QA 2.1/styles.css
+++ b/QA 2.1/styles.css
@@ -1108,6 +1108,30 @@ button.primary:focus-visible {
     color: var(--muted);
 }
 
+
+.section-range-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin: 10px 0 14px;
+}
+
+.section-range-controls label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--muted);
+}
+
+.section-range-controls input {
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--text);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 10px;
+    padding: 6px 8px;
+}
+
 .watch-columns {
     display: grid;
     gap: 18px;

--- a/QA 2.1/styles.css
+++ b/QA 2.1/styles.css
@@ -176,6 +176,10 @@ body.page {
     display: none;
 }
 
+.page-card.collapsed > :not(.card-header) {
+    display: none;
+}
+
 .page-card.table-card {
     overflow: hidden;
 }
@@ -1148,6 +1152,25 @@ button.primary:focus-visible {
 
 .filter-actions button {
     padding: 6px 10px;
+}
+
+.section-range-controls select option {
+    color: var(--text);
+    background: #101626;
+}
+
+.link-button {
+    border: none;
+    background: none;
+    color: var(--accent);
+    text-decoration: underline;
+    cursor: pointer;
+    padding: 0;
+    font: inherit;
+}
+
+.link-button:hover {
+    color: #7aa8ff;
 }
 
 .data-center-list .table {

--- a/QA 2.1/styles.css
+++ b/QA 2.1/styles.css
@@ -867,7 +867,7 @@ button.primary:focus-visible {
 
 .validation-row {
     display: grid;
-    grid-template-columns: minmax(160px, 2fr) minmax(200px, 3fr) auto;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)) auto;
     gap: 12px;
     align-items: center;
     padding: 16px;
@@ -887,7 +887,8 @@ button.primary:focus-visible {
     color: var(--muted);
 }
 
-.validation-row input[type="text"] {
+.validation-row input[type="text"],
+.validation-row select {
     width: 100%;
 }
 
@@ -1130,6 +1131,43 @@ button.primary:focus-visible {
     border: 1px solid rgba(255, 255, 255, 0.12);
     border-radius: 10px;
     padding: 6px 8px;
+}
+
+.section-range-controls select {
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--text);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 10px;
+    padding: 6px 8px;
+}
+
+.filter-actions {
+    display: inline-flex;
+    gap: 8px;
+}
+
+.filter-actions button {
+    padding: 6px 10px;
+}
+
+.data-center-list .table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.data-center-list .table th,
+.data-center-list .table td {
+    padding: 8px 10px;
+    text-align: left;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    font-size: 12px;
+}
+
+.data-center-list .table th {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 10px;
+    color: var(--muted);
 }
 
 .watch-columns {

--- a/QA 2.1/styles.css
+++ b/QA 2.1/styles.css
@@ -2045,3 +2045,55 @@ body.popup {
         display: none;
     }
 }
+
+.notification-list {
+    display: grid;
+    gap: 10px;
+}
+
+.notification-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.notification-row.is-read {
+    opacity: 0.55;
+}
+
+.notification-main {
+    display: grid;
+    gap: 4px;
+}
+
+.notification-title {
+    font-weight: 700;
+}
+
+.notification-description {
+    color: var(--muted);
+    font-size: 11px;
+}
+
+.notification-time {
+    color: var(--muted);
+    font-size: 10px;
+}
+
+.notification-actions {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.notification-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 10px;
+}


### PR DESCRIPTION
### Motivation
- Replace fragile array-based `chrome.storage.local.eventLogs` read/rewrites with a record-per-event IndexedDB store for reliability and performance.
- Ensure the Control Center analytics ignore repeated identical rows so trend counts (e.g. fatigue/hotspots) are not inflated by duplicate writes.
- Stop logging operator names and use `truckNumber` as the primary identifier in logs and UI. 
- Allow manual correction/removal of events by adding edit/delete controls in the Event Log UI.

### Description
- Added a new shared IndexedDB layer `event-log-db.js` that exposes `EventLogDB.upsert`, `getAll`, `remove`, `replaceAll`, `clearAll`, plus helpers `buildDuplicateKey` and `deriveEventDate`, and migrates legacy `chrome.storage.local.eventLogs` once to the DB.
- Replaced content-side persistence in `content.js` with `EventLogDB.upsert(...)` and stopped writing `operatorName` for new records, instead setting `operatorName` to empty and including `eventDate` for duplicate-key computation.
- Reworked `log.js` to load/save via `EventLogDB.getAll()`/`replaceAll()`, added deduplication by the duplicate key (Event Type + Timestamp + Date + Truck + Site), and implemented upsert semantics so differing validations overwrite existing duplicate records.
- Updated Event Log UI (`log.html`, `log.js`) to remove Operator columns, add a `Manage` column with per-row `Edit`/`Delete` buttons, an edit modal to change truck/event/validation/timestamp/site, and a delete confirmation flow; `saveLogs()` now persists to the DB.
- Updated QA Control Center (`qa-control.js`, `qa-control.html`) to read from `EventLogDB.getAll()`, deduplicate prior to analytics via `deduplicateForAnalytics` so duplicates are ignored when building fatigue watchlists and spotlights, and switched identity to truck+site (operator removed).
- Wired `event-log-db.js` into the extension by adding it to `manifest.json` content scripts and including it in pages that use the DB (`log.html`, `qa-control.html`).

### Testing
- Ran static checks `node --check` on `QA 2.1/event-log-db.js`, `QA 2.1/content.js`, `QA 2.1/log.js`, and `QA 2.1/qa-control.js`, all of which succeeded. 
- Executed unit/test script with `npm test` (inside `QA 2.1/`) and it passed: `All enabled state controller tests passed`.
- Attempted a Playwright-based screenshot of `log.html` to validate UI rendering, but the headless Chromium crashed in this environment (SIGSEGV), so no screenshot artifact was produced; code-level checks and tests still passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ce3598df8832591ef1e1c2058efb6)